### PR TITLE
[INTERNAL] Add PR Electron build workflow for Windows and macOS

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: windows-latest


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Introduce a pull request workflow that builds the Electron app for Windows x64, Windows ARM, macOS (Apple Silicon), and macOS (Intel), uploading unsigned build artifacts and commenting a summary on the PR.