### PR TITLE
[INTERNAL] Fix workflow names, use node 24

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,22 +9,23 @@ permissions:
   pull-requests: write
 jobs:
   build:
+    name: ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: windows-latest
-            name: Windows x86_64 (Unisgned)
+            name: Windows x86_64 (Unisigned)
             artifact: Electron-win64-build
             header: build-win64
             path: dist/*
           - os: windows-11-arm
-            name: Windows ARM x64 (Unisgned)
+            name: Windows ARM x64 (Unisigned)
             artifact: Electron-winaarch64-build
             header: build-arm
             path: dist/*
           - os: macos-latest
-            name: MacOS ARM x64 (Unisgned)
+            name: MacOS ARM x64 (Unisigned)
             artifact: Electron-macOS-build
             header: build-macos
             path: |
@@ -32,7 +33,7 @@ jobs:
               dist/*.zip
               dist/*.pkg
           - os: macos-15-intel
-            name: MacOS x86_64 (Unisgned)
+            name: MacOS x86_64 (Unisigned)
             artifact: Electron-macOS-x86-build
             header: build-macos-x86
             path: |


### PR DESCRIPTION
- Fix #36

## Summary by Sourcery

Standardize CI build workflows to target Node.js 24 and improve OS-specific job identification in the PR build matrix.

CI:
- Set PR build workflow to use Node.js 24 across all matrix jobs instead of per-job node versions.
- Add descriptive names for each OS/architecture entry in the PR build matrix for clearer identification.