### PR TITLE
[INTERNAL] Update dependabot npm directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directory: "src" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Fix #74

## Summary by Sourcery

Build:
- Adjust Dependabot npm configuration to use src as the package manifest directory.