### PR TITLE
Fix hanging requests by preventing starting server when port 11434 is already in use

### DIFF
--- a/src/node-apis/ollama.ts
+++ b/src/node-apis/ollama.ts
@@ -92,9 +92,9 @@ export async function serve(): Promise<string> {
 	}
 
 	return new Promise((resolve, reject) => {
-		exec(`"${ollamaPath}" serve`, (err: Error | null, stdout: string) => {
+		exec(`"${ollamaPath}" serve`, (err: Error | null, stdout: string, stderr: string) => {
 			if (err) {
-				console.log(stdout);
+				err.message += `: ${stderr}`;
 				reject(err);
 			} else {
 				resolve(stdout);


### PR DESCRIPTION
Fix #120 when multiple server instances cause the server to completely stop responding

## Summary by Sourcery

Bug Fixes:
- Prevent multiple Ollama server instances from being started when the target port is already in use.