### PR TITLE
Target zip only for Windows GPU builds

### DIFF
--- a/src/build.config.js
+++ b/src/build.config.js
@@ -64,7 +64,7 @@ export default {
 
 	win: {
 		target: isGpuBuild
-			? ["appx", "zip"]
+			? ["zip"]
 			: ["nsis", "appx", "zip", "msi"],
 
 		appId: "RihaanMeher.InferencePortAI_jgdzt0f3vt2yc",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust Windows GPU build targets to generate only a ZIP package.