### PR TITLE
Target 7z (7zip Archives) for Windows on GPU

### DIFF
--- a/src/build.config.js
+++ b/src/build.config.js
@@ -64,7 +64,7 @@ export default {
 
 	win: {
 		target: isGpuBuild
-			? ["zip"]
+			? ["7z"]
 			: ["nsis", "appx", "zip", "msi"],
 
 		appId: "RihaanMeher.InferencePortAI_jgdzt0f3vt2yc",


### PR DESCRIPTION
Fix #204
## Summary by Sourcery

Build:
- Change Windows GPU build target from zip to 7z archives.