### PR TITLE
Fix #206: Invalid emitWarning import

### DIFF
--- a/src/public/scripts/renderer/chat.ts
+++ b/src/public/scripts/renderer/chat.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 //@ts-nocheck
 
-import { emitWarning } from "node:process";
 import { showNotification } from "../helper/notification.js";
 import {
 	mergeLocalAndRemoteSessions,


### PR DESCRIPTION
Fix #206 so chat page now loads

## Summary by Sourcery

Bug Fixes:
- Resolve invalid emitWarning import in the chat renderer to restore chat page loading.