### PR TITLE
Update homepage music section branding to AceStep Turbo

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -711,7 +711,7 @@
 								<p>Create original, high-quality music and sound effects from a simple text prompt. From
 									cinematic scores to lo-fi beats, bring your audio ideas to life.</p>
 								<ul>
-									<li>Powered by ElevenLabs Music</li>
+									<li>Powered by AceStep Turbo</li>
 									<li>Full tracks &amp; sound effects</li>
 									<li>Multiple genres and styles</li>
 									<li>Studio quality audio outputs</li>


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update homepage music/SFX section to state it is powered by AceStep Turbo instead of ElevenLabs Music.