### PR TITLE
Fix start hosting issue (``DOMContentLoaded`` never runs in ``settings.ts``)

### DIFF
--- a/src/public/scripts/settings.ts
+++ b/src/public/scripts/settings.ts
@@ -505,8 +505,7 @@ async function openSettingsUpgradeModal() {
 		],
 	});
 }
-
-document.addEventListener("DOMContentLoaded", () => {
+(async () => {
 	installExternalUrlHandler();
 	hostConfigModal = new window.ic.iModal("host-config-modal", 650);
 	renameModal = new window.ic.iModal("rename-modal", 400);
@@ -546,8 +545,7 @@ document.addEventListener("DOMContentLoaded", () => {
 		accountButton?.click();
 		setTimeout(() => void openSettingsUpgradeModal(), 180);
 	}
-});
-
+}
 (async () => {
 	try {
 		const { session } = (await window.auth.getSession?.()) ?? {

--- a/src/public/scripts/settings.ts
+++ b/src/public/scripts/settings.ts
@@ -545,7 +545,7 @@ async function openSettingsUpgradeModal() {
 		accountButton?.click();
 		setTimeout(() => void openSettingsUpgradeModal(), 180);
 	}
-}
+})();
 (async () => {
 	try {
 		const { session } = (await window.auth.getSession?.()) ?? {


### PR DESCRIPTION
Fix #286

## Summary by Sourcery

Initialize settings page modals and handlers immediately via an async IIFE instead of waiting for the DOMContentLoaded event to resolve issues where the event does not fire.