### PR TITLE
Add Lightning API key management UI, IPC, and schema

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "webchat-server"]
 	path = webchat-server
 	url = https://huggingface.co/spaces/incognitolm/chat.git
-[submodule "lightning-api"]
-	path = lightning-api
-	url = https://hf.co/spaces/sharktide/lightning

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "webchat-server"]
 	path = webchat-server
 	url = https://huggingface.co/spaces/incognitolm/chat.git
+[submodule "lightning-api"]
+	path = lightning-api
+	url = https://hf.co/spaces/sharktide/lightning

--- a/MISC/api.sql
+++ b/MISC/api.sql
@@ -1,30 +1,44 @@
+-- ============================================================
+-- Extensions
+-- ============================================================
 create extension if not exists pgcrypto with schema extensions;
 
+-- ============================================================
+-- Table: lightning_api_keys
+-- ============================================================
 create table if not exists public.lightning_api_keys (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
   name text not null,
   key_hash text not null unique,
   key_prefix text not null,
-  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
-  last_used_at timestamp with time zone,
-  expires_at timestamp with time zone,
-  revoked_at timestamp with time zone,
+  created_at timestamptz not null default timezone('utc', now()),
+  last_used_at timestamptz,
+  expires_at timestamptz,
+  revoked_at timestamptz,
+
   constraint lightning_api_keys_name_length check (char_length(trim(name)) between 1 and 64),
   constraint lightning_api_keys_hash_length check (char_length(key_hash) = 64),
   constraint lightning_api_keys_prefix_length check (char_length(key_prefix) between 8 and 32)
 );
 
+-- ============================================================
+-- Indexes
+-- ============================================================
 create index if not exists lightning_api_keys_user_id_idx
   on public.lightning_api_keys (user_id, created_at desc);
 
 create index if not exists lightning_api_keys_lookup_idx
   on public.lightning_api_keys (key_hash);
 
+-- ============================================================
+-- Row Level Security
+-- ============================================================
 alter table public.lightning_api_keys enable row level security;
-
-grant select, insert, update, delete on public.lightning_api_keys to authenticated;
-
+DROP POLICY IF EXISTS "Users can read their own Lightning API keys" ON public.lightning_api_keys;
+DROP POLICY IF EXISTS "Users can create their own Lightning API keys" ON public.lightning_api_keys;
+DROP POLICY IF EXISTS "Users can update their own Lightning API keys" ON public.lightning_api_keys;
+DROP POLICY IF EXISTS "Users can delete their own Lightning API keys" ON public.lightning_api_keys;
 create policy "Users can read their own Lightning API keys"
 on public.lightning_api_keys
 for select
@@ -45,3 +59,49 @@ create policy "Users can delete their own Lightning API keys"
 on public.lightning_api_keys
 for delete
 using (auth.uid() = user_id);
+
+-- ============================================================
+-- Column-level SELECT permissions
+-- ============================================================
+revoke select on public.lightning_api_keys from authenticated;
+
+grant select (
+  id,
+  user_id,
+  name,
+  key_prefix,
+  created_at,
+  last_used_at,
+  expires_at,
+  revoked_at
+) on public.lightning_api_keys to authenticated;
+
+-- ============================================================
+-- Trigger Function: auto-delete AFTER update
+-- ============================================================
+create or replace function public.delete_lightning_key_on_revocation()
+returns trigger as $$
+begin
+  if new.revoked_at is not null then
+    delete from public.lightning_api_keys where id = new.id;
+    return null;
+  end if;
+
+  if new.expires_at is not null and new.expires_at <= now() then
+    delete from public.lightning_api_keys where id = new.id;
+    return null;
+  end if;
+
+  return new;
+end;
+$$ language plpgsql security definer;
+
+-- ============================================================
+-- Trigger (AFTER UPDATE so SELECT works)
+-- ============================================================
+drop trigger if exists lightning_key_auto_delete on public.lightning_api_keys;
+
+create trigger lightning_key_auto_delete
+after update on public.lightning_api_keys
+for each row
+execute function public.delete_lightning_key_on_revocation();

--- a/MISC/api.sql
+++ b/MISC/api.sql
@@ -18,7 +18,7 @@ create table if not exists public.lightning_api_keys (
   revoked_at timestamptz,
 
   constraint lightning_api_keys_name_length check (char_length(trim(name)) between 1 and 64),
-  constraint lightning_api_keys_hash_length check (char_length(key_hash) = 64),
+  constraint lightning_api_keys_hash_length check (char_length(key_hash) < 100),
   constraint lightning_api_keys_prefix_length check (char_length(key_prefix) between 8 and 32)
 );
 

--- a/MISC/api.sql
+++ b/MISC/api.sql
@@ -1,0 +1,47 @@
+create extension if not exists pgcrypto with schema extensions;
+
+create table if not exists public.lightning_api_keys (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  key_hash text not null unique,
+  key_prefix text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  last_used_at timestamp with time zone,
+  expires_at timestamp with time zone,
+  revoked_at timestamp with time zone,
+  constraint lightning_api_keys_name_length check (char_length(trim(name)) between 1 and 64),
+  constraint lightning_api_keys_hash_length check (char_length(key_hash) = 64),
+  constraint lightning_api_keys_prefix_length check (char_length(key_prefix) between 8 and 32)
+);
+
+create index if not exists lightning_api_keys_user_id_idx
+  on public.lightning_api_keys (user_id, created_at desc);
+
+create index if not exists lightning_api_keys_lookup_idx
+  on public.lightning_api_keys (key_hash);
+
+alter table public.lightning_api_keys enable row level security;
+
+grant select, insert, update, delete on public.lightning_api_keys to authenticated;
+
+create policy "Users can read their own Lightning API keys"
+on public.lightning_api_keys
+for select
+using (auth.uid() = user_id);
+
+create policy "Users can create their own Lightning API keys"
+on public.lightning_api_keys
+for insert
+with check (auth.uid() = user_id);
+
+create policy "Users can update their own Lightning API keys"
+on public.lightning_api_keys
+for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "Users can delete their own Lightning API keys"
+on public.lightning_api_keys
+for delete
+using (auth.uid() = user_id);

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-furo
+shibuya
 sphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-project = "InferencePort AI"
+project = "InferencePort AI Docs"
 copyright = "2026, Rihaan Meher"
 author = "Rihaan Meher"
 release = "2.2.0"
@@ -20,13 +20,16 @@ intersphinx_mapping = {
     "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }
 
-html_theme = "furo"
+html_theme = "shibuya"
 html_title = f"{project} documentation"
 html_static_path = ["_static"]
+html_context = {
+    "source_type": "github",
+    "source_user": "sharktide",
+    "source_repo": "inferenceport-ai",
+    "source_version": "main",
+    "source_docs_path": "/docs/source/",
+}
 html_theme_options = {
-    "source_repository": "https://github.com/sharktide/inferenceport-ai/",
-    "source_branch": "main",
-    "source_directory": "docs/source/",
-    "collapse_navigation": False,
-    "navigation_depth": 4,
+    "github_url": "https://github.com/sharktide/inferenceport-ai/",
 }

--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -10,6 +10,7 @@ InferencePort AI from source.
 
    architecture
    ipc-api
+   lightning-api
    development
    build-release
    security-privacy

--- a/docs/source/developer/ipc-api.rst
+++ b/docs/source/developer/ipc-api.rst
@@ -236,6 +236,15 @@ Utility methods:
    * - ``setUsername(userId, username)``
      - ``auth:setUsername``
      - Create/update profile username.
+   * - ``listLightningApiKeys()``
+     - ``auth:listLightningApiKeys``
+     - List the authenticated user's Lightning API keys.
+   * - ``createLightningApiKey(name, expiresAt?)``
+     - ``auth:createLightningApiKey``
+     - Create a hashed Lightning API key row and return the raw secret once.
+   * - ``revokeLightningApiKey(keyId)``
+     - ``auth:revokeLightningApiKey``
+     - Revoke an existing Lightning API key.
 
 ``window.sync``
 ---------------

--- a/docs/source/developer/lightning-api.rst
+++ b/docs/source/developer/lightning-api.rst
@@ -1,0 +1,268 @@
+Lightning API
+=============
+
+The Lightning API is the hosted cloud API behind InferencePort AI Lightning.
+Its base URL is ``https://sharktide-lightning.hf.space`` and the generation
+routes live under ``/gen``.
+
+Authentication
+--------------
+
+Lightning accepts either of these bearer tokens:
+
+* A Supabase access token for the signed-in user.
+* A dashboard-generated Lightning API key.
+
+Send both forms the same way:
+
+.. code-block:: bash
+
+   curl https://sharktide-lightning.hf.space/subscription \
+     -H "Authorization: Bearer YOUR_TOKEN"
+
+Generating API keys in the app
+------------------------------
+
+1. Sign in inside the desktop app.
+2. Open ``Settings``.
+3. Open the ``Account`` tab.
+4. In ``Lightning API``, choose ``Generate API Key``.
+5. Copy the key immediately. Only the unhashed secret is shown once.
+
+The backing Supabase schema and RLS policies live in ``MISC/api.sql``.
+Keys are stored hashed in ``public.lightning_api_keys`` and are scoped to the
+owning user via ``auth.uid()`` RLS policies.
+
+Headers
+-------
+
+Common request headers:
+
+* ``Authorization: Bearer <supabase-jwt-or-api-key>`` for authenticated usage.
+* ``X-Client-ID: <stable-client-id>`` to bind free-tier and usage tracking to a
+  stable desktop/browser client.
+* ``Accept: application/json`` for JSON endpoints.
+
+Plan and usage endpoints
+------------------------
+
+``GET /subscription``
+~~~~~~~~~~~~~~~~~~~~~
+
+Returns the authenticated user's resolved plan and Stripe subscription view.
+
+Response fields:
+
+* ``email``
+* ``signed_up``
+* ``plan_key``
+* ``plan_name``
+* ``subscription``: ``null`` for free users, otherwise a list of active or
+  recent subscription rows
+* ``auth_type``: ``jwt`` or ``api_key``
+
+``GET /usage``
+~~~~~~~~~~~~~~
+
+Returns the current usage snapshot for the resolved identity.
+
+Response fields:
+
+* ``plan_key``
+* ``plan_name``
+* ``generated_at``
+* ``usage.cloudChatDaily``
+* ``usage.imagesDaily``
+* ``usage.videosDaily``
+* ``usage.audioWeekly``
+
+Each usage metric contains:
+
+* ``limit``
+* ``used``
+* ``remaining``
+* ``window``
+* ``period``
+
+``GET /tier-config``
+~~~~~~~~~~~~~~~~~~~~
+
+Returns the normalized plan catalog used by the app UI:
+
+* ``defaultPlanKey``
+* ``plans[]`` with ``key``, ``name``, ``url``, ``price``, ``limits``, and
+  ``order``
+
+``GET /tiers``
+~~~~~~~~~~~~~~
+
+Returns the paid plans only, mainly for upgrade UI.
+
+Status and discovery endpoints
+------------------------------
+
+``GET /``
+~~~~~~~~~
+
+Permanent redirect to the public site.
+
+``GET /models``
+~~~~~~~~~~~~~~~
+
+Scrapes the Ollama library page and returns public model metadata used by the
+marketplace UI.
+
+``GET /status``
+~~~~~~~~~~~~~~~
+
+Returns overall Lightning service health with:
+
+* ``state``
+* ``services``
+* ``notifications``
+* ``latest``
+
+``HEAD /status/image``, ``/status/video``, ``/status/sfx``, ``/status/text``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lightweight capability checks that return content-type headers only.
+
+Generation endpoints
+--------------------
+
+All generation routes are rooted at ``/gen``.
+
+``POST /gen/chat/completions``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+OpenAI-compatible chat completions endpoint.
+
+Important request fields:
+
+* ``messages``: required array
+* ``stream``: optional boolean
+* ``tools``: optional tool list
+* ``tool_choice``: optional tool selection
+
+Behavior notes:
+
+* Lightning chooses an upstream model automatically based on prompt complexity,
+  code signals, tools, and image presence.
+* Authenticated requests consume ``cloudChatDaily`` usage from the resolved
+  plan.
+* Streaming responses are returned as ``text/event-stream``.
+* The first streaming metadata chunk includes ``router_metadata.model_name``.
+
+Example:
+
+.. code-block:: bash
+
+   curl https://sharktide-lightning.hf.space/gen/chat/completions \
+     -H "Authorization: Bearer YOUR_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "messages": [
+         {"role": "user", "content": "Write a haiku about shipping software."}
+       ]
+     }'
+
+``POST /gen/image`` and ``GET /gen/image/{prompt}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Image generation endpoint.
+
+Request fields:
+
+* ``prompt``: required
+* ``mode``: optional, ``fantasy`` or ``realistic``
+* ``image_urls``: optional list with up to two URLs or base64 image strings
+
+Notes:
+
+* Base64 image inputs are stored temporarily and re-served through
+  ``/asset-cdn/assets/{image_id}``.
+* Image generation consumes ``imagesDaily`` usage.
+
+``POST /gen/video`` and ``GET /gen/video/{prompt}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pollinations-backed video generation.
+
+Request fields:
+
+* ``prompt``: required
+* ``ratio``: optional, ``3:2``, ``2:3``, or ``1:1``
+* ``mode``: optional, ``normal`` or ``fun``
+* ``duration``: optional integer, clamped to ``1`` through ``10``
+* ``image_urls``: optional list with up to two URLs or base64 image strings
+
+Video generation consumes ``videosDaily`` usage.
+
+``POST /gen/video/airforce`` and ``GET /gen/video/airforce/{prompt}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Alternate Airforce-backed video endpoint with the same auth model. It also
+consumes ``videosDaily`` usage.
+
+``POST /gen/sfx`` and ``GET /gen/sfx/{prompt}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Music and sound-effect generation. Requires ``prompt`` and consumes
+``audioWeekly`` usage.
+
+``POST /gen/tts`` and ``GET /gen/tts/{prompt}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Text-to-speech generation. Requires ``prompt`` and also consumes
+``audioWeekly`` usage.
+
+``POST /gen/prompt_analyze``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns the router's chosen display model for a prompt payload. The request body
+expects ``prompt`` as a message array.
+
+Asset CDN
+---------
+
+``GET /asset-cdn/assets/{image_id}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns temporary PNG files created when image or video generation receives
+base64 image inputs.
+
+Rate limits
+-----------
+
+Lightning currently tracks these metrics per resolved identity:
+
+* ``cloudChatDaily``
+* ``imagesDaily``
+* ``videosDaily``
+* ``audioWeekly``
+
+If no bearer token is present, Lightning falls back to a free-tier identity
+derived from ``X-Client-ID`` when available, otherwise from request IP and
+user-agent.
+
+Failure modes
+-------------
+
+Common status codes:
+
+* ``400`` for invalid request payloads
+* ``401`` for invalid, expired, or revoked bearer credentials
+* ``413`` for prompts that exceed configured size limits
+* ``429`` for plan rate-limit exhaustion
+* ``500`` for upstream provider or server configuration failures
+
+Implementation notes
+--------------------
+
+Relevant files:
+
+* ``lightning-api/app.py``
+* ``lightning-api/gen.py``
+* ``lightning-api/helper/ratelimit.py``
+* ``lightning-api/helper/subscriptions.py``
+* ``MISC/api.sql``

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -107,7 +107,8 @@ If needed, sign in from ``Auth`` using:
 * GitHub
 * Google
 
-Settings includes account actions such as username change and account deletion.
+Settings includes account actions such as username change, account deletion,
+subscription management, and Lightning API key generation.
 
 Sync (Optional)
 ---------------

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -100,6 +100,24 @@ declare global {
 		error?: string;
 	};
 
+	type AuthLightningApiKey = {
+		id: string;
+		name: string;
+		keyPrefix: string;
+		createdAt: string;
+		lastUsedAt: string | null;
+		expiresAt: string | null;
+		revokedAt: string | null;
+		isRevoked: boolean;
+		isExpired: boolean;
+	};
+
+	type AuthLightningApiKeyCreateResponse = {
+		apiKey?: AuthLightningApiKey;
+		rawKey?: string;
+		error?: string;
+	};
+
 	interface declarations {
 		iInstance: iInstance;
 		iFunctions: iFunctions;
@@ -232,6 +250,18 @@ declare global {
 			getSubscriptionTiers: () => Promise<AuthSubscriptionTier[]>;
 			getTierConfig: () => Promise<AuthTierConfig | null>;
 			getUsage: () => Promise<AuthUsageInfo>;
+			listLightningApiKeys: () => Promise<AuthLightningApiKey[]>;
+			createLightningApiKey: (
+				name: string,
+				expiresAt?: string | null,
+			) => Promise<AuthLightningApiKeyCreateResponse>;
+			revokeLightningApiKey: (
+				keyId: string,
+			) => Promise<{
+				success?: boolean;
+				apiKey?: AuthLightningApiKey;
+				error?: string;
+			}>;
 		};
 
 		sync: {

--- a/src/node-apis/auth.ts
+++ b/src/node-apis/auth.ts
@@ -1,6 +1,12 @@
 import { createClient } from "@supabase/supabase-js";
-import type { Session, AuthChangeEvent, Subscription } from "@supabase/supabase-js";
+import type {
+	AuthChangeEvent,
+	Session,
+	Subscription,
+	SupabaseClient,
+} from "@supabase/supabase-js";
 import { app, ipcMain, session } from "electron";
+import { createHash, randomBytes } from "node:crypto";
 
 import fs from "fs";
 import path from "path";
@@ -109,6 +115,34 @@ type RendererSessionView = {
 type RendererProfileView = {
 	username: string;
 } | null;
+
+type LightningApiKeyRow = {
+	id?: unknown;
+	name?: unknown;
+	key_prefix?: unknown;
+	created_at?: unknown;
+	last_used_at?: unknown;
+	expires_at?: unknown;
+	revoked_at?: unknown;
+};
+
+type RendererLightningApiKeyView = {
+	id: string;
+	name: string;
+	keyPrefix: string;
+	createdAt: string;
+	lastUsedAt: string | null;
+	expiresAt: string | null;
+	revokedAt: string | null;
+	isRevoked: boolean;
+	isExpired: boolean;
+};
+
+type RendererLightningApiKeyCreateResult = {
+	apiKey?: RendererLightningApiKeyView;
+	rawKey?: string;
+	error?: string;
+};
 
 export const sessionFile = path.join(app.getPath("userData"), "supabase-session.json");
 const profilesFile = path.join(app.getPath("userData"), "profiles.json");
@@ -232,6 +266,110 @@ function asTrimmedString(value: unknown): string | null {
 	if (typeof value !== "string") return null;
 	const trimmed = value.trim();
 	return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeIsoTimestamp(value: unknown): string | null {
+	const trimmed = asTrimmedString(value);
+	if (!trimmed) return null;
+	const parsed = Date.parse(trimmed);
+	if (Number.isNaN(parsed)) return null;
+	return new Date(parsed).toISOString();
+}
+
+function isIsoTimestampExpired(value: string | null): boolean {
+	if (!value) return false;
+	const expiresAt = Date.parse(value);
+	return Number.isFinite(expiresAt) && expiresAt <= Date.now();
+}
+
+function normalizeLightningApiKey(
+	value: unknown,
+): RendererLightningApiKeyView | null {
+	if (!value || typeof value !== "object") return null;
+	const row = value as LightningApiKeyRow;
+	const id = asTrimmedString(row.id);
+	const name = asTrimmedString(row.name);
+	const keyPrefix = asTrimmedString(row.key_prefix);
+	const createdAt = normalizeIsoTimestamp(row.created_at);
+	if (!id || !name || !keyPrefix || !createdAt) return null;
+
+	const lastUsedAt = normalizeIsoTimestamp(row.last_used_at);
+	const expiresAt = normalizeIsoTimestamp(row.expires_at);
+	const revokedAt = normalizeIsoTimestamp(row.revoked_at);
+
+	return {
+		id,
+		name,
+		keyPrefix,
+		createdAt,
+		lastUsedAt,
+		expiresAt,
+		revokedAt,
+		isRevoked: revokedAt !== null,
+		isExpired: revokedAt === null && isIsoTimestampExpired(expiresAt),
+	};
+}
+
+async function getAuthenticatedSupabaseClient(): Promise<{
+	client: SupabaseClient;
+	session: Session;
+}> {
+	const { data, error } = await supabase.auth.getSession();
+	if (error) {
+		throw error;
+	}
+	if (!data.session?.access_token) {
+		throw new Error("No active session");
+	}
+
+	return {
+		session: data.session,
+		client: createClient(supabaseUrl, supabaseKey, {
+			global: {
+				headers: {
+					Authorization: `Bearer ${data.session.access_token}`,
+				},
+			},
+		}),
+	};
+}
+
+function buildLightningApiKeySecret(): string {
+	return `ipa_live_${randomBytes(24).toString("base64url")}`;
+}
+
+function hashLightningApiKey(secret: string): string {
+	return createHash("sha256").update(secret).digest("hex");
+}
+
+function buildLightningApiKeyPrefix(secret: string): string {
+	return secret.slice(0, 16);
+}
+
+function parseLightningApiKeyExpiry(value?: string | null): string | null {
+	const trimmed = asTrimmedString(value);
+	if (!trimmed) return null;
+	const parsed = Date.parse(trimmed);
+	if (Number.isNaN(parsed)) {
+		throw new Error("Expiration date must be a valid ISO timestamp");
+	}
+	return new Date(parsed).toISOString();
+}
+
+async function listLightningApiKeys(): Promise<RendererLightningApiKeyView[]> {
+	const { client } = await getAuthenticatedSupabaseClient();
+	const { data, error } = await client
+		.from("lightning_api_keys")
+		.select("id, name, key_prefix, created_at, last_used_at, expires_at, revoked_at")
+		.order("created_at", { ascending: false });
+
+	if (error) {
+		throw new Error(error.message);
+	}
+
+	return (data || [])
+		.map((entry) => normalizeLightningApiKey(entry))
+		.filter((entry): entry is RendererLightningApiKeyView => Boolean(entry));
 }
 
 function normalizePlanKeyFromName(planName: string | null): string {
@@ -773,6 +911,111 @@ export default function register() {
 		}
 	});
 
+	ipcMain.handle("auth:listLightningApiKeys", async () => {
+		try {
+			return await listLightningApiKeys();
+		} catch (error) {
+			throw new Error(
+				error instanceof Error ? error.message : String(error),
+			);
+		}
+	});
+
+	ipcMain.handle(
+		"auth:createLightningApiKey",
+		async (_event, name: string, expiresAt?: string | null) => {
+			const normalizedName = asTrimmedString(name);
+			if (!normalizedName) {
+				return { error: "API key name is required" };
+			}
+			if (normalizedName.length > 64) {
+				return { error: "API key name must be 64 characters or fewer" };
+			}
+
+			try {
+				const parsedExpiresAt = parseLightningApiKeyExpiry(expiresAt);
+				const { client, session } = await getAuthenticatedSupabaseClient();
+				const rawKey = buildLightningApiKeySecret();
+				const keyHash = hashLightningApiKey(rawKey);
+				const keyPrefix = buildLightningApiKeyPrefix(rawKey);
+
+				const { data, error } = await client
+					.from("lightning_api_keys")
+					.insert({
+						user_id: session.user.id,
+						name: normalizedName,
+						key_hash: keyHash,
+						key_prefix: keyPrefix,
+						expires_at: parsedExpiresAt,
+					})
+					.select(
+						"id, name, key_prefix, created_at, last_used_at, expires_at, revoked_at",
+					)
+					.single();
+
+				if (error) {
+					return { error: error.message };
+				}
+
+				const normalized = normalizeLightningApiKey(data);
+				if (!normalized) {
+					return { error: "Created API key response was invalid" };
+				}
+
+				const result: RendererLightningApiKeyCreateResult = {
+					apiKey: normalized,
+					rawKey,
+				};
+				return result;
+			} catch (error) {
+				return {
+					error: error instanceof Error ? error.message : String(error),
+				};
+			}
+		},
+	);
+
+	ipcMain.handle(
+		"auth:revokeLightningApiKey",
+		async (_event, keyId: string) => {
+			const normalizedKeyId = asTrimmedString(keyId);
+			if (!normalizedKeyId) {
+				return { error: "API key id is required" };
+			}
+
+			try {
+				const { client } = await getAuthenticatedSupabaseClient();
+				const { data, error } = await client
+					.from("lightning_api_keys")
+					.update({ revoked_at: new Date().toISOString() })
+					.eq("id", normalizedKeyId)
+					.is("revoked_at", null)
+					.select(
+						"id, name, key_prefix, created_at, last_used_at, expires_at, revoked_at",
+					)
+					.maybeSingle();
+
+				if (error) {
+					return { error: error.message };
+				}
+				if (!data) {
+					return { error: "API key not found or already revoked" };
+				}
+
+				const normalized = normalizeLightningApiKey(data);
+				if (!normalized) {
+					return { error: "Updated API key response was invalid" };
+				}
+
+				return { success: true, apiKey: normalized };
+			} catch (error) {
+				return {
+					error: error instanceof Error ? error.message : String(error),
+				};
+			}
+		},
+	);
+
 	ipcMain.handle(
 		"auth:setSessionTokens",
 		async (_event, accessToken: string, refreshToken: string) => {
@@ -808,18 +1051,14 @@ export default function register() {
 			if (!userId || !username)
 				return { error: "Missing userId or username" };
 
-			const { data: sessionData, error: sessionError } =
-				await supabase.auth.getSession();
-			if (sessionError || !sessionData.session)
-				return { error: "No active session" };
-
-			const authedClient = createClient(supabaseUrl, supabaseKey, {
-				global: {
-					headers: {
-						Authorization: `Bearer ${sessionData.session.access_token}`,
-					},
-				},
-			});
+			let authedClient: SupabaseClient;
+			try {
+				({ client: authedClient } = await getAuthenticatedSupabaseClient());
+			} catch (error) {
+				return {
+					error: error instanceof Error ? error.message : String(error),
+				};
+			}
 
 			const { data: existing, error: checkError } = await authedClient
 				.from("profiles")

--- a/src/node-apis/auth.ts
+++ b/src/node-apis/auth.ts
@@ -6,7 +6,7 @@ import type {
 	SupabaseClient,
 } from "@supabase/supabase-js";
 import { app, ipcMain, session } from "electron";
-import { createHash, randomBytes } from "node:crypto";
+import { randomBytes, scryptSync } from "node:crypto";
 
 import fs from "fs";
 import path from "path";
@@ -339,7 +339,9 @@ function buildLightningApiKeySecret(): string {
 }
 
 function hashLightningApiKey(secret: string): string {
-	return createHash("sha256").update(secret).digest("hex");
+	const salt = randomBytes(16);
+	const derivedKey = scryptSync(secret, salt, 32);
+	return `scrypt$${salt.toString("base64url")}$${derivedKey.toString("base64url")}`;
 }
 
 function buildLightningApiKeyPrefix(secret: string): string {

--- a/src/preload.cts
+++ b/src/preload.cts
@@ -211,6 +211,17 @@ contextBridge.exposeInMainWorld("auth", {
 	getSubscriptionTiers: () => ipcRenderer.invoke("auth:getSubscriptionTiers"),
 	getTierConfig: () => ipcRenderer.invoke("auth:getTierConfig"),
 	getUsage: (): Promise<AuthUsageInfo> => ipcRenderer.invoke("auth:getUsage"),
+	listLightningApiKeys: (): Promise<AuthLightningApiKey[]> =>
+		ipcRenderer.invoke("auth:listLightningApiKeys"),
+	createLightningApiKey: (
+		name: string,
+		expiresAt?: string | null,
+	): Promise<AuthLightningApiKeyCreateResponse> =>
+		ipcRenderer.invoke("auth:createLightningApiKey", name, expiresAt),
+	revokeLightningApiKey: (
+		keyId: string,
+	): Promise<{ success?: boolean; apiKey?: AuthLightningApiKey; error?: string }> =>
+		ipcRenderer.invoke("auth:revokeLightningApiKey", keyId),
 });
 
 // ===== Sync =====

--- a/src/public/scripts/helper/ipcTransportFallback.ts
+++ b/src/public/scripts/helper/ipcTransportFallback.ts
@@ -1062,6 +1062,22 @@ export function installWebSocketTransportFallback(): void {
 			invokeOrDefault<AuthTierConfig | null>("auth:getTierConfig", []),
 		getUsage: async () =>
 			invokeOrDefault<AuthUsageInfo>("auth:getUsage", []),
+		listLightningApiKeys: async () =>
+			invokeOrDefault<AuthLightningApiKey[]>("auth:listLightningApiKeys", []),
+		createLightningApiKey: async (
+			name: string,
+			expiresAt?: string | null,
+		) =>
+			invokeOrDefault<AuthLightningApiKeyCreateResponse>(
+				"auth:createLightningApiKey",
+				[name, expiresAt ?? null],
+			),
+		revokeLightningApiKey: async (keyId: string) =>
+			invokeOrDefault<{
+				success?: boolean;
+				apiKey?: AuthLightningApiKey;
+				error?: string;
+			}>("auth:revokeLightningApiKey", [keyId]),
 		setSessionFromTokens: async (
 			accessToken: string,
 			refreshToken: string,

--- a/src/public/scripts/settings.ts
+++ b/src/public/scripts/settings.ts
@@ -100,6 +100,8 @@ let deleteConfirmModal: declarations["iInstance"]["iModal"];
 let deletePasswordModal: declarations["iInstance"]["iModal"];
 let settingsUpgradeModal: declarations["iInstance"]["iModal"];
 let settingsUpgradeAuthModal: declarations["iInstance"]["iModal"];
+let apiKeyCreateModal: declarations["iInstance"]["iModal"];
+let apiKeyRevealModal: declarations["iInstance"]["iModal"];
 
 const settingsUpgradeBtn = document.getElementById(
 	"settings-upgrade-btn",
@@ -119,6 +121,18 @@ const subscriptionManagementCopyEl = document.getElementById(
 const subscriptionManagementStepsEl = document.getElementById(
 	"subscription-management-steps",
 ) as HTMLOListElement | null;
+const settingsApiRefreshBtn = document.getElementById(
+	"settings-api-refresh-btn",
+) as HTMLButtonElement | null;
+const settingsApiCreateBtn = document.getElementById(
+	"settings-api-create-btn",
+) as HTMLButtonElement | null;
+const settingsApiStatusEl = document.getElementById(
+	"settings-api-status",
+) as HTMLParagraphElement | null;
+const settingsApiListEl = document.getElementById(
+	"settings-api-list",
+) as HTMLDivElement | null;
 type PlanKey = "free" | "light" | "core" | "creator" | "professional";
 const PLAN_ORDER: PlanKey[] = [
 	"free",
@@ -160,9 +174,289 @@ let currentPlanName: string = PLAN_DISPLAY_NAMES.free;
 let subscriptionTiers: AuthSubscriptionTier[] = [];
 let isUpgradeUserAuthenticated = false;
 let currentTierConfig: AuthTierConfig | null = null;
+let lightningApiKeys: AuthLightningApiKey[] = [];
 
 function escapeHtml(value: string): string {
 	return escapeSubscriptionHtml(value);
+}
+
+function formatDateTime(value: string | null): string {
+	if (!value) return "Never";
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return value;
+	return parsed.toLocaleString();
+}
+
+function getApiKeyStatus(
+	apiKey: AuthLightningApiKey,
+): { label: string; className: string } {
+	if (apiKey.isRevoked) {
+		return { label: "Revoked", className: "is-revoked" };
+	}
+	if (apiKey.isExpired) {
+		return { label: "Expired", className: "is-expired" };
+	}
+	return { label: "Active", className: "is-active" };
+}
+
+function renderLightningApiKeys(): void {
+	if (!settingsApiListEl) return;
+
+	if (!isUpgradeUserAuthenticated) {
+		settingsApiListEl.innerHTML =
+			'<p class="settings-api-empty">Sign in to create and manage Lightning API keys.</p>';
+		return;
+	}
+
+	if (!Array.isArray(lightningApiKeys) || lightningApiKeys.length === 0) {
+		settingsApiListEl.innerHTML =
+			'<p class="settings-api-empty">No API keys yet. Generate one to authenticate Lightning requests without a Supabase session JWT.</p>';
+		return;
+	}
+
+	settingsApiListEl.innerHTML = lightningApiKeys
+		.map((apiKey) => {
+			const status = getApiKeyStatus(apiKey);
+			return `
+				<article class="settings-api-key-row">
+					<div class="settings-api-key-head">
+						<div class="settings-api-key-title">
+							<div class="settings-api-key-name">${escapeHtml(apiKey.name)}</div>
+							<div class="settings-api-key-prefix">${escapeHtml(apiKey.keyPrefix)}...</div>
+						</div>
+						<div class="settings-api-key-badge ${status.className}">${escapeHtml(status.label)}</div>
+					</div>
+					<div class="settings-api-key-meta">
+						<span>Created: ${escapeHtml(formatDateTime(apiKey.createdAt))}</span>
+						<span>Last used: ${escapeHtml(formatDateTime(apiKey.lastUsedAt))}</span>
+						<span>Expires: ${escapeHtml(apiKey.expiresAt ? formatDateTime(apiKey.expiresAt) : "Never")}</span>
+					</div>
+					<div class="settings-api-actions">
+						<button
+							type="button"
+							class="theme-toggle settings-subscription-btn settings-subscription-btn--secondary"
+							data-api-key-action="revoke"
+							data-api-key-id="${escapeHtml(apiKey.id)}"
+							${apiKey.isRevoked ? "disabled" : ""}
+						>
+							${apiKey.isRevoked ? "Revoked" : "Revoke Key"}
+						</button>
+					</div>
+				</article>
+			`;
+		})
+		.join("");
+
+	settingsApiListEl
+		.querySelectorAll<HTMLButtonElement>('[data-api-key-action="revoke"]')
+		.forEach((button) => {
+			button.addEventListener("click", () => {
+				const keyId = button.dataset.apiKeyId;
+				if (!keyId) return;
+				void revokeLightningApiKey(keyId);
+			});
+		});
+}
+
+function setLightningApiStatus(message: string, tone: "default" | "warning" = "default"): void {
+	if (!settingsApiStatusEl) return;
+	settingsApiStatusEl.textContent = message;
+	settingsApiStatusEl.style.color =
+		tone === "warning" ? "#d38200ff" : "";
+}
+
+async function refreshLightningApiKeys(force = false): Promise<void> {
+	if (!isUpgradeUserAuthenticated && !force) {
+		lightningApiKeys = [];
+		setLightningApiStatus(
+			"Sign in to create and manage Lightning API keys.",
+			"warning",
+		);
+		renderLightningApiKeys();
+		return;
+	}
+
+	try {
+		const { session } = await window.auth.getSession();
+		isUpgradeUserAuthenticated = Boolean(session?.isAuthenticated);
+		if (!isUpgradeUserAuthenticated) {
+			lightningApiKeys = [];
+			setLightningApiStatus(
+				"Sign in to create and manage Lightning API keys.",
+				"warning",
+			);
+			renderLightningApiKeys();
+			return;
+		}
+
+		lightningApiKeys = await window.auth.listLightningApiKeys();
+		setLightningApiStatus(
+			"Use a generated key as `Authorization: Bearer <your-api-key>` when calling Lightning.",
+		);
+		renderLightningApiKeys();
+	} catch (error) {
+		lightningApiKeys = [];
+		setLightningApiStatus(
+			`Could not load API keys: ${error instanceof Error ? error.message : String(error)}`,
+			"warning",
+		);
+		renderLightningApiKeys();
+	}
+}
+
+function bindCopyApiKeyButton(rawKey: string): void {
+	setTimeout(() => {
+		const copyButton = document.getElementById(
+			"copy-lightning-api-key",
+		) as HTMLButtonElement | null;
+		const statusEl = document.getElementById(
+			"copy-lightning-api-key-status",
+		) as HTMLParagraphElement | null;
+		if (!copyButton) return;
+		copyButton.addEventListener("click", async () => {
+			try {
+				await navigator.clipboard.writeText(rawKey);
+				if (statusEl) statusEl.textContent = "Copied to clipboard.";
+			} catch (error) {
+				if (statusEl) {
+					statusEl.textContent = `Copy failed: ${error instanceof Error ? error.message : String(error)}`;
+				}
+			}
+		});
+	}, 0);
+}
+
+function openApiKeyRevealModal(apiKey: AuthLightningApiKey, rawKey: string): void {
+	if (!apiKeyRevealModal) return;
+	apiKeyRevealModal.open({
+		html: `
+			<div style="text-align:left">
+				<h3>API key created</h3>
+				<p>Copy this key now. For security, it is only shown once.</p>
+				<p><strong>${escapeHtml(apiKey.name)}</strong></p>
+				<pre style="white-space:pre-wrap;word-break:break-all;">${escapeHtml(rawKey)}</pre>
+				<p id="copy-lightning-api-key-status" class="muted">Use it as <code>Authorization: Bearer &lt;your-api-key&gt;</code>.</p>
+			</div>
+		`,
+		actions: [
+			{
+				id: "copy-lightning-api-key",
+				label: "Copy Key",
+				onClick: async () => {
+					try {
+						await navigator.clipboard.writeText(rawKey);
+						showNotification({
+							message: "API key copied to clipboard",
+							type: "success",
+						});
+					} catch (error) {
+						showNotification({
+							message: `Copy failed: ${error instanceof Error ? error.message : String(error)}`,
+							type: "warning",
+						});
+					}
+				},
+			},
+			{
+				id: "close-lightning-api-key",
+				label: "Close",
+				onClick: () => apiKeyRevealModal.close(),
+			},
+		],
+	});
+	bindCopyApiKeyButton(rawKey);
+}
+
+function openCreateApiKeyModal(): void {
+	if (!apiKeyCreateModal) return;
+	apiKeyCreateModal.open({
+		html: `
+			<div style="text-align:left">
+				<h3>Create Lightning API key</h3>
+				<p>Give this key a label so you can recognize where it is used later.</p>
+				<input type="text" id="lightning-api-key-name" placeholder="Production deploy, local scripts, CI, etc." style="width:100%">
+				<p style="margin:12px 0 6px;">Optional expiration (ISO date/time)</p>
+				<input type="text" id="lightning-api-key-expiry" placeholder="2026-12-31T23:59:59Z" style="width:100%">
+				<p id="lightning-api-key-create-status" style="margin-top:8px;"></p>
+			</div>
+		`,
+		actions: [
+			{
+				id: "create-lightning-api-key-cancel",
+				label: "Cancel",
+				onClick: () => apiKeyCreateModal.close(),
+			},
+			{
+				id: "create-lightning-api-key-submit",
+				label: "Generate",
+				onClick: async () => {
+					const nameInput = document.getElementById(
+						"lightning-api-key-name",
+					) as HTMLInputElement | null;
+					const expiryInput = document.getElementById(
+						"lightning-api-key-expiry",
+					) as HTMLInputElement | null;
+					const statusEl = document.getElementById(
+						"lightning-api-key-create-status",
+					) as HTMLParagraphElement | null;
+					const name = nameInput?.value.trim() || "";
+					const expiresAt = expiryInput?.value.trim() || null;
+
+					if (!name) {
+						if (statusEl) statusEl.textContent = "Please enter a name for this key.";
+						return;
+					}
+
+					if (statusEl) statusEl.textContent = "Creating API key...";
+
+					const result = await window.auth.createLightningApiKey(name, expiresAt);
+					if (result.error || !result.apiKey || !result.rawKey) {
+						if (statusEl) {
+							statusEl.textContent = `Error: ${result.error || "Could not create API key"}`;
+						}
+						return;
+					}
+
+					apiKeyCreateModal.close();
+					lightningApiKeys = [result.apiKey, ...lightningApiKeys];
+					setLightningApiStatus(
+						"New key created. Copy it now before closing the reveal dialog.",
+					);
+					renderLightningApiKeys();
+					openApiKeyRevealModal(result.apiKey, result.rawKey);
+				},
+			},
+		],
+	});
+}
+
+async function revokeLightningApiKey(keyId: string): Promise<void> {
+	const target = lightningApiKeys.find((entry) => entry.id === keyId);
+	if (!target) return;
+
+	const confirmed = window.confirm(
+		`Revoke the API key "${target.name}"? Existing integrations using it will stop working immediately.`,
+	);
+	if (!confirmed) return;
+
+	const result = await window.auth.revokeLightningApiKey(keyId);
+	if (!result.success || !result.apiKey) {
+		showNotification({
+			message: result.error || "Could not revoke API key",
+			type: "warning",
+		});
+		return;
+	}
+
+	lightningApiKeys = lightningApiKeys.map((entry) =>
+		entry.id === keyId ? result.apiKey! : entry,
+	);
+	setLightningApiStatus(`Revoked API key "${target.name}".`);
+	renderLightningApiKeys();
+	showNotification({
+		message: `Revoked API key "${target.name}"`,
+		type: "success",
+	});
 }
 
 function isKnownPlanKey(value: string): value is PlanKey {
@@ -525,6 +819,20 @@ async function openSettingsUpgradeModal() {
 		false,
 		false,
 	);
+	apiKeyCreateModal = new window.ic.iModal(
+		"settings-api-key-create-modal",
+		560,
+		undefined,
+		false,
+		false,
+	);
+	apiKeyRevealModal = new window.ic.iModal(
+		"settings-api-key-reveal-modal",
+		620,
+		undefined,
+		false,
+		false,
+	);
 
 	settingsUpgradeBtn?.addEventListener("click", () => {
 		void openSettingsUpgradeModal();
@@ -532,10 +840,35 @@ async function openSettingsUpgradeModal() {
 	settingsPortalBtn?.addEventListener("click", () => {
 		openBillingPortal();
 	});
+	settingsApiRefreshBtn?.addEventListener("click", () => {
+		void refreshLightningApiKeys(true);
+	});
+	settingsApiCreateBtn?.addEventListener("click", () => {
+		refreshLightningApiKeys(true)
+			.then(() => {
+				if (!isUpgradeUserAuthenticated) {
+					showNotification({
+						message: "Sign in to generate Lightning API keys",
+						type: "warning",
+					});
+					return;
+				}
+				openCreateApiKeyModal();
+			})
+			.catch((error) => {
+				showNotification({
+					message: `Could not open API key dialog: ${error instanceof Error ? error.message : String(error)}`,
+					type: "warning",
+				});
+			});
+	});
 	void refreshUpgradeSubscriptionData(true);
+	void refreshLightningApiKeys(true);
 	window.auth.onAuthStateChange((session) => {
 		isUpgradeUserAuthenticated = Boolean(session?.isAuthenticated);
+		setAccountControlsEnabled(isUpgradeUserAuthenticated);
 		void refreshUpgradeSubscriptionData(true);
+		void refreshLightningApiKeys(true);
 	});
 
 	if (window.location.hash.replace(/^#/, "").toLowerCase() === "upgrade") {
@@ -822,18 +1155,14 @@ emailInput.addEventListener("blur", () => {
 	emailInput.value = "";
 });
 
-window.addEventListener("DOMContentLoaded", async () => {
-	const { session } = await window.auth.getSession();
-	if (session?.isAuthenticated) return;
-	const shouldDisable = true;
-
+function setAccountControlsEnabled(enabled: boolean): void {
 	const details = document.getElementById("account-settings");
 	if (!details) return;
 
 	const buttons = details.querySelectorAll("button");
 
 	buttons.forEach((btn) => {
-		if (shouldDisable) {
+		if (!enabled) {
 			btn.classList.add("disabled");
 			btn.disabled = true;
 		} else {
@@ -842,14 +1171,27 @@ window.addEventListener("DOMContentLoaded", async () => {
 		}
 	});
 
-	const msg = document.createElement("p");
-	const br = document.createElement("p");
-	br.textContent = " ";
-	details.appendChild(br);
-	msg.className = "muted";
-	msg.style.color = "#d38200ff";
-	msg.textContent = "Sign in to use account controls.";
-	details.appendChild(msg);
+	const existingHint = details.querySelector(
+		'[data-account-auth-hint="true"]',
+	) as HTMLParagraphElement | null;
+
+	if (!enabled) {
+		if (existingHint) return;
+		const msg = document.createElement("p");
+		msg.dataset.accountAuthHint = "true";
+		msg.className = "muted";
+		msg.style.color = "#d38200ff";
+		msg.textContent = "Sign in to use account controls.";
+		details.appendChild(msg);
+		return;
+	}
+
+	existingHint?.remove();
+}
+
+window.addEventListener("DOMContentLoaded", async () => {
+	const { session } = await window.auth.getSession();
+	setAccountControlsEnabled(Boolean(session?.isAuthenticated));
 });
 
 async function setHostingUIRunning(running: boolean, port?: number) {

--- a/src/public/scripts/settings.ts
+++ b/src/public/scripts/settings.ts
@@ -448,9 +448,16 @@ async function revokeLightningApiKey(keyId: string): Promise<void> {
                 label: "Revoke",
                 onClick: async () => {
                     modal.close();
-
-                    const result = await window.auth.revokeLightningApiKey(keyId);
-
+		    let result
+		    try {
+                    	result = await window.auth.revokeLightningApiKey(keyId);
+		    } catch {
+			result = {
+			    success: null,
+			    apiKey: null,
+			    error: null
+			}
+		    }
                     if (!result.success || !result.apiKey) {
                         showNotification({
                             message: result.error || "Could not revoke API key",

--- a/src/public/scripts/settings.ts
+++ b/src/public/scripts/settings.ts
@@ -431,32 +431,51 @@ function openCreateApiKeyModal(): void {
 }
 
 async function revokeLightningApiKey(keyId: string): Promise<void> {
-	const target = lightningApiKeys.find((entry) => entry.id === keyId);
-	if (!target) return;
+    const target = lightningApiKeys.find((entry) => entry.id === keyId);
+    if (!target) return;
 
-	const confirmed = window.confirm(
-		`Revoke the API key "${target.name}"? Existing integrations using it will stop working immediately.`,
-	);
-	if (!confirmed) return;
+    const modal = new window.ic.iModal("revoke-api-key-modal", 420, {
+        title: "Revoke API Key",
+        text: `Revoke the API key "${target.name}"? Existing integrations using it will stop working immediately.`,
+        actions: [
+            {
+                id: "cancel-revoke",
+                label: "Cancel",
+                onClick: () => modal.close(),
+            },
+            {
+                id: "confirm-revoke",
+                label: "Revoke",
+                onClick: async () => {
+                    modal.close();
 
-	const result = await window.auth.revokeLightningApiKey(keyId);
-	if (!result.success || !result.apiKey) {
-		showNotification({
-			message: result.error || "Could not revoke API key",
-			type: "warning",
-		});
-		return;
-	}
+                    const result = await window.auth.revokeLightningApiKey(keyId);
 
-	lightningApiKeys = lightningApiKeys.map((entry) =>
-		entry.id === keyId ? result.apiKey! : entry,
-	);
-	setLightningApiStatus(`Revoked API key "${target.name}".`);
-	renderLightningApiKeys();
-	showNotification({
-		message: `Revoked API key "${target.name}"`,
-		type: "success",
-	});
+                    if (!result.success || !result.apiKey) {
+                        showNotification({
+                            message: result.error || "Could not revoke API key",
+                            type: "warning",
+                        });
+                        return;
+                    }
+
+                    lightningApiKeys = lightningApiKeys.map((entry) =>
+                        entry.id === keyId ? result.apiKey! : entry,
+                    );
+
+                    setLightningApiStatus(`Revoked API key "${target.name}".`);
+                    renderLightningApiKeys();
+
+                    showNotification({
+                        message: `Revoked API key "${target.name}"`,
+                        type: "success",
+                    });
+                },
+            },
+        ],
+    });
+
+    modal.open();
 }
 
 function isKnownPlanKey(value: string): value is PlanKey {

--- a/src/public/settings.html
+++ b/src/public/settings.html
@@ -94,7 +94,7 @@
 									<li>Use the billing portal later to change or upgrade your subscription.</li>
 								</ol>
 							</section>
-							<section class="settings-api-card">
+							<section class="settings-api-card" style="margin-top: 10px;">
 								<div class="settings-api-card-header">
 									<div>
 										<p class="settings-subscription-kicker">Lightning API</p>

--- a/src/public/settings.html
+++ b/src/public/settings.html
@@ -94,6 +94,31 @@
 									<li>Use the billing portal later to change or upgrade your subscription.</li>
 								</ol>
 							</section>
+							<section class="settings-api-card">
+								<div class="settings-api-card-header">
+									<div>
+										<p class="settings-subscription-kicker">Lightning API</p>
+										<h3>Manage API keys</h3>
+										<p class="settings-api-copy">
+											Create long-lived API keys for Lightning so scripts and servers can authenticate without a Supabase session JWT.
+										</p>
+									</div>
+									<div class="settings-api-actions">
+										<button id="settings-api-refresh-btn" class="theme-toggle settings-subscription-btn settings-subscription-btn--secondary">
+											Refresh Keys
+										</button>
+										<button id="settings-api-create-btn" class="theme-toggle settings-upgrade-btn">
+											Generate API Key
+										</button>
+									</div>
+								</div>
+								<p id="settings-api-status" class="muted">
+									Sign in to create and manage Lightning API keys.
+								</p>
+								<div id="settings-api-list" class="settings-api-list">
+									<p class="settings-api-empty">No API keys yet.</p>
+								</div>
+							</section>
 							<section id="upgrade-section" class="settings-upgrade-section">
 								<h3>Upgrade Plan</h3>
 								<p id="upgrade-plan-info">Unlock higher limits, premium models, and priority support by upgrading your plan.</p>

--- a/src/public/styles/pages/settings.css
+++ b/src/public/styles/pages/settings.css
@@ -168,6 +168,124 @@ Copyright 2025 Rihaan Meher
   gap: 14px;
 }
 
+.settings-api-card {
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--text-dark) 12%, transparent);
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--bg-light) 94%, transparent),
+      color-mix(in srgb, var(--secondary-color) 28%, transparent)
+    );
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+  display: grid;
+  gap: 14px;
+}
+
+.settings-api-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.settings-api-copy {
+  margin: 8px 0 0;
+  color: color-mix(in srgb, var(--text-dark) 84%, transparent);
+  line-height: 1.55;
+}
+
+.settings-api-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.settings-api-list {
+  display: grid;
+  gap: 10px;
+}
+
+.settings-api-empty {
+  margin: 0;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px dashed color-mix(in srgb, var(--text-dark) 18%, transparent);
+  background: color-mix(in srgb, var(--bg-primary) 76%, transparent);
+}
+
+.settings-api-key-row {
+  display: grid;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--text-dark) 12%, transparent);
+  background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
+}
+
+.settings-api-key-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.settings-api-key-title {
+  display: grid;
+  gap: 4px;
+}
+
+.settings-api-key-name {
+  font-weight: 700;
+}
+
+.settings-api-key-prefix {
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.86rem;
+  color: color-mix(in srgb, var(--text-dark) 75%, transparent);
+}
+
+.settings-api-key-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text-dark) 74%, transparent);
+}
+
+.settings-api-key-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.settings-api-key-badge.is-active {
+  background: color-mix(in srgb, #178f5f 18%, transparent);
+  color: #126744;
+}
+
+.settings-api-key-badge.is-expired {
+  background: color-mix(in srgb, #d38200 18%, transparent);
+  color: #945d00;
+}
+
+.settings-api-key-badge.is-revoked {
+  background: color-mix(in srgb, var(--error) 18%, transparent);
+  color: color-mix(in srgb, var(--error) 80%, #611919 20%);
+}
+
+.settings-api-key-row button {
+  min-width: 140px;
+}
+
 .settings-subscription-header {
   display: flex;
   justify-content: space-between;
@@ -256,11 +374,13 @@ Copyright 2025 Rihaan Meher
 }
 
 @media (max-width: 768px) {
+  .settings-api-actions,
   .settings-subscription-actions,
   .settings-account-actions {
     width: 100%;
   }
 
+  .settings-api-actions button,
   .settings-subscription-btn,
   .settings-upgrade-btn {
     flex: 1 1 100%;


### PR DESCRIPTION
## Summary by Sourcery

Add management of long-lived Lightning API keys, including creation, listing, and revocation, wired through the auth IPC layer, UI, and database schema.

New Features:
- Introduce Lightning API key entities and IPC methods to list, create, and revoke keys tied to the authenticated Supabase user.
- Add a settings UI section for managing Lightning API keys, including generating keys, viewing metadata, and revoking keys, with responsive styling.
- Expose Lightning API key operations in the preload and web socket IPC fallback layers for renderer access.
- Add a database schema and RLS policies for storing hashed Lightning API keys with prefixes, timestamps, and auto-deletion on revocation or expiry.

Enhancements:
- Refine account controls enabling/disabling behavior based on auth state and reuse it for both initial load and auth state changes.
- Centralize authenticated Supabase client creation for reuse across auth-related operations.

Documentation:
- Stub out a new developer documentation page for the Lightning API.