### PR TITLE
Add UI-visible Progress Bar for Token Verification Usage Limits

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -100,6 +100,16 @@ declare global {
 		error?: string;
 	};
 
+	type AuthVerifyTokenUsageInfo = {
+		planKey: string;
+		planName: string;
+		featureName: string;
+		usage: AuthUsageMetric;
+		generatedAt: string | null;
+		notice?: string;
+		error?: string;
+	};
+
 	type AuthLightningApiKey = {
 		id: string;
 		name: string;
@@ -254,6 +264,7 @@ declare global {
 			getSubscriptionTiers: () => Promise<AuthSubscriptionTier[]>;
 			getTierConfig: () => Promise<AuthTierConfig | null>;
 			getUsage: () => Promise<AuthUsageInfo>;
+			getVerifyTokenUsage: () => Promise<AuthVerifyTokenUsageInfo>;
 			listLightningApiKeys: () => Promise<AuthLightningApiKey[]>;
 			createLightningApiKey: (
 				name: string,

--- a/src/node-apis/auth.ts
+++ b/src/node-apis/auth.ts
@@ -25,6 +25,7 @@ const subscriptionDetailsUrl = `${subscriptionApiBase}/subscription`;
 const subscriptionTiersUrl = `${subscriptionApiBase}/tiers`;
 const subscriptionTierConfigUrl = `${subscriptionApiBase}/tier-config`;
 const subscriptionUsageUrl = `${subscriptionApiBase}/usage`;
+const verifyTokenUsageUrl = `${subscriptionApiBase}/usage/verify-token-with-email`;
 
 type SubscriptionTierView = {
 	key?: string;
@@ -85,6 +86,10 @@ type UsageMetricKey =
 	| "videosDaily"
 	| "audioWeekly";
 
+type StandaloneUsageMetricKey =
+	| UsageMetricKey
+	| "verifyTokenWithEmailDaily";
+
 type RendererUsageMetricView = {
 	limit: number | null;
 	used: number;
@@ -98,6 +103,16 @@ export type RendererUsageView = {
 	planName: string;
 	metrics: Record<UsageMetricKey, RendererUsageMetricView>;
 	generatedAt: string | null;
+	error?: string;
+};
+
+type RendererVerifyTokenUsageView = {
+	planKey: string;
+	planName: string;
+	featureName: string;
+	usage: RendererUsageMetricView;
+	generatedAt: string | null;
+	notice?: string;
 	error?: string;
 };
 
@@ -489,9 +504,31 @@ function createUsageFallback(
 	};
 }
 
+function createVerifyTokenUsageFallback(
+	tierConfig: SubscriptionTierConfigView | null,
+	error?: string,
+): RendererVerifyTokenUsageView {
+	const defaultPlanKey = tierConfig?.defaultPlanKey || "free";
+	const planName =
+		tierConfig?.plans.find((p) => p.key === defaultPlanKey)?.name || "Free Tier";
+	return {
+		planKey: defaultPlanKey,
+		planName,
+		featureName: "Token Verification Requests",
+		usage: {
+			...defaultUsageMetric("daily"),
+			limit: 100,
+			remaining: 100,
+		},
+		generatedAt: null,
+		notice: "Need more usage? Contact us at inferenceportai@gmail.com.",
+		...(error ? { error } : {}),
+	};
+}
+
 function normalizeUsageMetric(
 	value: unknown,
-	key: UsageMetricKey,
+	key: StandaloneUsageMetricKey,
 	planLimit: number | null,
 ): RendererUsageMetricView {
 	const fallbackPeriod = key === "audioWeekly" ? "weekly" : "daily";
@@ -521,6 +558,47 @@ function normalizeUsageMetric(
 		remaining,
 		window,
 		period,
+	};
+}
+
+function normalizeVerifyTokenUsageView(
+	value: unknown,
+	tierConfig: SubscriptionTierConfigView | null,
+): RendererVerifyTokenUsageView | null {
+	if (!value || typeof value !== "object") return null;
+	const asRecord = value as Record<string, unknown>;
+	const tierMap = new Map((tierConfig?.plans || []).map((plan) => [plan.key, plan]));
+	const payloadPlanKey = asTrimmedString(asRecord.plan_key)?.toLowerCase();
+	let planKey =
+		payloadPlanKey && tierMap.has(payloadPlanKey)
+			? payloadPlanKey
+			: normalizePlanKeyFromName(asTrimmedString(asRecord.plan_name));
+	if (tierMap.size > 0 && !tierMap.has(planKey)) {
+		planKey = tierConfig?.defaultPlanKey || "free";
+	}
+	const planName =
+		tierMap.get(planKey)?.name ||
+		asTrimmedString(asRecord.plan_name) ||
+		"Free Tier";
+	const usage = normalizeUsageMetric(
+		asRecord.usage,
+		"verifyTokenWithEmailDaily",
+		100,
+	);
+
+	return {
+		planKey,
+		planName,
+		featureName:
+			asTrimmedString(asRecord.feature_name) || "Token Verification Requests",
+		usage,
+		generatedAt: asTrimmedString(asRecord.generated_at),
+		notice:
+			asTrimmedString(asRecord.notice) ||
+			"Need more usage? Contact us at inferenceportai@gmail.com.",
+		...(asTrimmedString(asRecord.error)
+			? { error: asTrimmedString(asRecord.error)! }
+			: {}),
 	};
 }
 
@@ -732,6 +810,65 @@ async function getUsageSafe(
 	}
 }
 
+async function getVerifyTokenUsageSafe(
+	tierConfig: SubscriptionTierConfigView | null,
+): Promise<RendererVerifyTokenUsageView> {
+	const fallback = createVerifyTokenUsageFallback(tierConfig);
+	let accessToken: string | null = null;
+	try {
+		const { data, error } = await supabase.auth.getSession();
+		if (!error && data.session?.access_token) {
+			accessToken = data.session.access_token;
+		}
+	} catch (_err) {
+		void 0;
+	}
+
+	const makeHeaders = (includeAuth: boolean): Record<string, string> => {
+		const headers: Record<string, string> = {
+			Accept: "application/json",
+		};
+		if (includeAuth && accessToken) {
+			headers.Authorization = `Bearer ${accessToken}`;
+		}
+		return headers;
+	};
+
+	try {
+		let res = await fetch(verifyTokenUsageUrl, {
+			headers: makeHeaders(Boolean(accessToken)),
+		});
+
+		if ((res.status === 401 || res.status === 403) && accessToken) {
+			res = await fetch(verifyTokenUsageUrl, {
+				headers: makeHeaders(false),
+			});
+		}
+
+		if (!res.ok) {
+			return {
+				...fallback,
+				error: `Usage lookup failed (${res.status})`,
+			};
+		}
+
+		const payload = await res.json();
+		const normalized = normalizeVerifyTokenUsageView(payload, tierConfig);
+		if (!normalized) {
+			return {
+				...fallback,
+				error: "Usage payload invalid",
+			};
+		}
+		return normalized;
+	} catch (err) {
+		return {
+			...fallback,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}
+
 function toSubscriptionView(
 	payload: RemoteSubscriptionPayload | null,
 	tiers: SubscriptionTierView[],
@@ -856,6 +993,11 @@ export default function register() {
 	ipcMain.handle("auth:getUsage", async () => {
 		const tierConfig = await getSubscriptionTierConfigSafe();
 		return await getUsageSafe(tierConfig);
+	});
+
+	ipcMain.handle("auth:getVerifyTokenUsage", async () => {
+		const tierConfig = await getSubscriptionTierConfigSafe();
+		return await getVerifyTokenUsageSafe(tierConfig);
 	});
 
 	ipcMain.handle("auth:getSubscriptionInfo", async () => {

--- a/src/node-apis/helper/proxy52458Client.ts
+++ b/src/node-apis/helper/proxy52458Client.ts
@@ -76,10 +76,16 @@ async function bodyToBuffer(body: BodyInit): Promise<Buffer> {
 	return Buffer.from(String(body), "utf8");
 }
 
-async function fetchCapabilities(baseOrigin: string): Promise<boolean> {
+async function fetchCapabilities(
+	baseOrigin: string,
+	bearer: string,
+): Promise<boolean> {
 	try {
 		const res = await fetch(`${baseOrigin}${CAPABILITIES_PATH}`, {
 			method: "GET",
+			headers: {
+				Authorization: `Bearer ${bearer}`,
+			},
 			cache: "no-store",
 		});
 		if (!res.ok) return false;
@@ -94,13 +100,13 @@ async function establishSession(
 	baseOrigin: string,
 	bearer: string,
 ): Promise<SessionState | null> {
-	const supported = await fetchCapabilities(baseOrigin);
+	const supported = await fetchCapabilities(baseOrigin, bearer);
 	if (!supported) {
 		if (!warnedLegacy.has(baseOrigin)) {
 			warnedLegacy.set(baseOrigin, true);
 			console.warn(
-				`[InferencePort] Proxy at ${baseOrigin} does not support encrypted client payloads (GET ${CAPABILITIES_PATH}). ` +
-					"Bearer tokens and request bodies may be sent in cleartext on the HTTP link. Update the host app or use HTTPS in front of the proxy.",
+				`[InferencePort] Proxy at ${baseOrigin} did not grant encrypted transport for this client (GET ${CAPABILITIES_PATH}). ` +
+					"Traffic can still work, but bearer tokens and request bodies may be sent in cleartext on the HTTP link. Use the API-backed app flow, update the host app, or place HTTPS in front of the proxy.",
 			);
 		}
 		return null;
@@ -220,18 +226,17 @@ export function createSecure52458Fetch(
 		}
 
 		const origin = parsed.origin;
+		const bearer = await getBearer();
 		let session = sessionByOrigin.get(origin);
 		if (
 			!session ||
 			session.expiresAt <= Date.now() + SESSION_REFRESH_MS
 		) {
-			const bearer = await getBearer();
 			session = await establishSession(origin, bearer);
 			sessionByOrigin.set(origin, session);
 		}
 
 		if (!session) {
-			const bearer = await getBearer();
 			const headers = new Headers(init?.headers);
 			headers.set("Authorization", `Bearer ${bearer}`);
 			return fetch(input, { ...init, headers });
@@ -240,6 +245,7 @@ export function createSecure52458Fetch(
 		const headers = new Headers(init?.headers);
 		headers.delete("authorization");
 		headers.set("X-Inferenceport-Session", session.sessionId);
+		headers.set("Authorization", `Bearer ${bearer}`);
 
 		const method = (init?.method || "GET").toUpperCase();
 		let body = init?.body;

--- a/src/node-apis/helper/server.ts
+++ b/src/node-apis/helper/server.ts
@@ -5,6 +5,7 @@ import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import { app } from "electron";
+import { getSession } from "../auth.js";
 import { getHardwareRating } from "./sysinfo.js";
 import { deriveIpcSessionKey } from "./ecdhAesSession.js";
 import { maybeDecryptIncomingProxyBody } from "./proxy52458Client.js";
@@ -246,35 +247,47 @@ function forwardRequest(
 	});
 }
 
-function verifyToken(
+async function verifyToken(
 	token: string | undefined | null,
 	emails: string[],
-	callback: (status: number, result: any | null) => void,
-) {
-	if (!token) return callback(401, null);
+): Promise<{ status: number; result: any | null }> {
+	if (!token) return { status: 401, result: null };
 
 	const body = JSON.stringify({ token, emails });
 	const url = new URL(VERIFY_URL);
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
 
-	const req = https.request(
-		url,
-		{ method: "POST", headers: { "Content-Type": "application/json" } },
-		(res) => {
+	try {
+		const session = await getSession();
+		if (session?.access_token) {
+			headers.Authorization = `Bearer ${session.access_token}`;
+		}
+	} catch {
+		void 0;
+	}
+
+	return await new Promise((resolve) => {
+		const req = https.request(url, { method: "POST", headers }, (res) => {
 			let data = "";
 			res.on("data", (chunk) => (data += chunk));
 			res.on("end", () => {
 				try {
-					callback(res.statusCode ?? 500, JSON.parse(data));
+					resolve({
+						status: res.statusCode ?? 500,
+						result: JSON.parse(data),
+					});
 				} catch {
-					callback(res.statusCode ?? 500, null);
+					resolve({ status: res.statusCode ?? 500, result: null });
 				}
 			});
-		},
-	);
+		});
 
-	req.on("error", () => callback(500, null));
-	req.write(body);
-	req.end();
+		req.on("error", () => resolve({ status: 500, result: null }));
+		req.write(body);
+		req.end();
+	});
 }
 
 export function startProxyServer(
@@ -542,12 +555,37 @@ export function startProxyServer(
 			return res.end();
 		}
 
+		const authHeader = req.headers["authorization"];
+		const bearerToken = extractBearerToken(authHeader);
 		const pathnameEarly = pathOnly(req);
 		if (req.method === "GET" && pathnameEarly === PATH_CRYPTO_CAPABILITIES) {
-			res.writeHead(200, { "Content-Type": "application/json" });
-			return res.end(
-				JSON.stringify({ supported: true, version: 1 }),
-			);
+			if (!bearerToken || serverApiKeys.includes(bearerToken)) {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				return res.end(
+					JSON.stringify({
+						supported: false,
+						version: 1,
+						reason: "api-verification-required",
+					}),
+				);
+			}
+
+			void verifyToken(
+				bearerToken,
+				allowedUsers.map((u) => u.email),
+			).then(({ status, result }) => {
+				const supported =
+					status === 200 && Boolean(result?.found) && Boolean(result?.email);
+				res.writeHead(200, { "Content-Type": "application/json" });
+				return res.end(
+					JSON.stringify({
+						supported,
+						version: 1,
+						...(supported ? {} : { reason: "api-verification-required" }),
+					}),
+				);
+			});
+			return;
 		}
 
 		logLine(
@@ -558,8 +596,6 @@ export function startProxyServer(
 		const sessionHeader = req.headers["x-inferenceport-session"];
 		const sessionId =
 			typeof sessionHeader === "string" ? sessionHeader.trim() : "";
-		const authHeader = req.headers["authorization"];
-		const bearerToken = extractBearerToken(authHeader);
 
 		if (sessionId) {
 			const sess = lookupCryptoSession(sessionId);
@@ -569,12 +605,57 @@ export function startProxyServer(
 					JSON.stringify({ error: "Invalid or expired session" }),
 				);
 			}
-			const matched = allowedUsers.find((u) => u.email === sess.email);
-			if (!matched) {
-				res.writeHead(403, { "Content-Type": "application/json" });
-				return res.end(JSON.stringify({ error: "Access denied" }));
+			if (!bearerToken) {
+				res.writeHead(401, { "Content-Type": "application/json" });
+				return res.end(
+					JSON.stringify({ error: "Missing Authorization header" }),
+				);
 			}
-			routeVerifiedRequest(req, res, matched, sess.key, ip);
+			logLine(
+				"INFO",
+				`Verifying session request token: ${maskToken(bearerToken)}`,
+			);
+			void verifyToken(
+				bearerToken,
+				allowedUsers.map((u) => u.email),
+			).then(({ status, result }) => {
+				if (status === 429) {
+					res.writeHead(429, { "Content-Type": "application/json" });
+					return res.end(
+						JSON.stringify({
+							error:
+								typeof result?.error === "string"
+									? result.error
+									: "Token verification limit reached for today.",
+							notice:
+								typeof result?.notice === "string" ? result.notice : undefined,
+							usage: result?.usage ?? undefined,
+						}),
+					);
+				}
+
+				if (status !== 200 || !result?.found || !result.email) {
+					res.writeHead(401, { "Content-Type": "application/json" });
+					return res.end(
+						JSON.stringify({ error: "Token verification failed" }),
+					);
+				}
+
+				if (result.email !== sess.email) {
+					res.writeHead(403, { "Content-Type": "application/json" });
+					return res.end(
+						JSON.stringify({ error: "Session token email mismatch" }),
+					);
+				}
+
+				const matched = allowedUsers.find((u) => u.email === result.email);
+				if (!matched) {
+					res.writeHead(403, { "Content-Type": "application/json" });
+					return res.end(JSON.stringify({ error: "Access denied" }));
+				}
+
+				routeVerifiedRequest(req, res, matched, sess.key, ip);
+			});
 			return;
 		}
 
@@ -599,28 +680,40 @@ export function startProxyServer(
 
 		logLine("INFO", `Verifying token: ${maskToken(bearerToken)}`);
 
-		verifyToken(
+		void verifyToken(
 			bearerToken,
 			allowedUsers.map((u) => u.email),
-			(status, result) => {
-				if (status !== 200 || !result?.found || !result.email) {
-					res.writeHead(401, { "Content-Type": "application/json" });
-					return res.end(
-						JSON.stringify({ error: "Token verification failed" }),
-					);
-				}
-
-				const matched = allowedUsers.find(
-					(u) => u.email === result.email,
+		).then(({ status, result }) => {
+			if (status === 429) {
+				res.writeHead(429, { "Content-Type": "application/json" });
+				return res.end(
+					JSON.stringify({
+						error:
+							typeof result?.error === "string"
+								? result.error
+								: "Token verification limit reached for today.",
+						notice:
+							typeof result?.notice === "string" ? result.notice : undefined,
+						usage: result?.usage ?? undefined,
+					}),
 				);
-				if (!matched) {
-					res.writeHead(403, { "Content-Type": "application/json" });
-					return res.end(JSON.stringify({ error: "Access denied" }));
-				}
+			}
 
-				routeVerifiedRequest(req, res, matched, null, ip);
-			},
-		);
+			if (status !== 200 || !result?.found || !result.email) {
+				res.writeHead(401, { "Content-Type": "application/json" });
+				return res.end(
+					JSON.stringify({ error: "Token verification failed" }),
+				);
+			}
+
+			const matched = allowedUsers.find((u) => u.email === result.email);
+			if (!matched) {
+				res.writeHead(403, { "Content-Type": "application/json" });
+				return res.end(JSON.stringify({ error: "Access denied" }));
+			}
+
+			routeVerifiedRequest(req, res, matched, null, ip);
+		});
 	});
 
 	server.listen(port, "0.0.0.0", () => {

--- a/src/preload.cts
+++ b/src/preload.cts
@@ -215,6 +215,8 @@ contextBridge.exposeInMainWorld("auth", {
 	getSubscriptionTiers: () => ipcRenderer.invoke("auth:getSubscriptionTiers"),
 	getTierConfig: () => ipcRenderer.invoke("auth:getTierConfig"),
 	getUsage: (): Promise<AuthUsageInfo> => ipcRenderer.invoke("auth:getUsage"),
+	getVerifyTokenUsage: (): Promise<AuthVerifyTokenUsageInfo> =>
+		ipcRenderer.invoke("auth:getVerifyTokenUsage"),
 	listLightningApiKeys: (): Promise<AuthLightningApiKey[]> =>
 		ipcRenderer.invoke("auth:listLightningApiKeys"),
 	createLightningApiKey: (

--- a/src/public/scripts/helper/ipcTransportFallback.ts
+++ b/src/public/scripts/helper/ipcTransportFallback.ts
@@ -1260,6 +1260,11 @@ export function installWebSocketTransportFallback(): void {
 			invokeOrDefault<AuthTierConfig | null>("auth:getTierConfig", []),
 		getUsage: async () =>
 			invokeOrDefault<AuthUsageInfo>("auth:getUsage", []),
+		getVerifyTokenUsage: async () =>
+			invokeOrDefault<AuthVerifyTokenUsageInfo>(
+				"auth:getVerifyTokenUsage",
+				[],
+			),
 		listLightningApiKeys: async () =>
 			invokeOrDefault<AuthLightningApiKey[]>("auth:listLightningApiKeys", []),
 		createLightningApiKey: async (

--- a/src/public/scripts/settings.ts
+++ b/src/public/scripts/settings.ts
@@ -32,6 +32,18 @@ const logsRefreshBtn = document.getElementById(
 const logsStartBtn = document.getElementById("logs-start") as HTMLButtonElement;
 const logsStopBtn = document.getElementById("logs-stop") as HTMLButtonElement;
 const logsOutput = document.getElementById("logs-output") as HTMLPreElement;
+const tokenVerifyUsageValueEl = document.getElementById(
+	"token-verify-usage-value",
+) as HTMLSpanElement | null;
+const tokenVerifyUsageFillEl = document.getElementById(
+	"token-verify-usage-fill",
+) as HTMLDivElement | null;
+const tokenVerifyUsageMetaEl = document.getElementById(
+	"token-verify-usage-meta",
+) as HTMLParagraphElement | null;
+const tokenVerifyUsageNoticeEl = document.getElementById(
+	"token-verify-usage-notice",
+) as HTMLParagraphElement | null;
 
 const RESTART_REQUIRED_KEY = "host_restart_required";
 
@@ -435,58 +447,65 @@ function openCreateApiKeyModal(): void {
 }
 
 async function revokeLightningApiKey(keyId: string): Promise<void> {
-    const target = lightningApiKeys.find((entry) => entry.id === keyId);
-    if (!target) return;
+	const target = lightningApiKeys.find((entry) => entry.id === keyId);
+	if (!target) return;
 
-    const modal = new window.ic.iModal("revoke-api-key-modal", 420, {
-        title: "Revoke API Key",
-        text: `Revoke the API key "${target.name}"? Existing integrations using it will stop working immediately.`,
-        actions: [
-            {
-                id: "cancel-revoke",
-                label: "Cancel",
-                onClick: () => modal.close(),
-            },
-            {
-                id: "confirm-revoke",
-                label: "Revoke",
-                onClick: async () => {
-                    modal.close();
-		    let result
-		    try {
-                    	result = await window.auth.revokeLightningApiKey(keyId);
-		    } catch {
-			result = {
-			    success: null,
-			    apiKey: null,
-			    error: null
-			}
-		    }
-                    if (!result.success || !result.apiKey) {
-                        showNotification({
-                            message: result.error || "Could not revoke API key",
-                            type: "warning",
-                        });
-                        return;
-                    }
+	let modal: any;
+	modal = new window.ic.iModal("revoke-api-key-modal", 420, {
+		title: "Revoke API Key",
+		text: `Revoke the API key "${target.name}"? Existing integrations using it will stop working immediately.`,
+		actions: [
+			{
+				id: "cancel-revoke",
+				label: "Cancel",
+				onClick: () => modal.close(),
+			},
+			{
+				id: "confirm-revoke",
+				label: "Revoke",
+				onClick: async () => {
+					modal.close();
+					let result:
+						| {
+								success?: boolean | null;
+								apiKey?: AuthLightningApiKey | null;
+								error?: string | null;
+						  }
+						| undefined;
+					try {
+						result = await window.auth.revokeLightningApiKey(keyId);
+					} catch {
+						result = {
+							success: null,
+							apiKey: null,
+							error: null,
+						};
+					}
+					if (!result.success || !result.apiKey) {
+						showNotification({
+							message: result.error || "Could not revoke API key",
+							type: "warning",
+						});
+						return;
+					}
 
-                    lightningApiKeys = lightningApiKeys.map((entry) =>
-                        entry.id === keyId ? result.apiKey! : entry,
-                    );
+					lightningApiKeys = lightningApiKeys.map((entry) =>
+						entry.id === keyId ? result.apiKey! : entry,
+					);
 
-                    setLightningApiStatus(`Revoked API key "${target.name}".`);
-                    renderLightningApiKeys();
+					setLightningApiStatus(`Revoked API key "${target.name}".`);
+					renderLightningApiKeys();
 
-                    showNotification({
-                        message: `Revoked API key "${target.name}"`,
-                        type: "success",
-                    });
-                },
-            },
-        ],
-    });
+					showNotification({
+						message: `Revoked API key "${target.name}"`,
+						type: "success",
+					});
+				},
+			},
+		],
+	});
 
-    modal.open();
+	modal.open();
 }
 
 function isKnownPlanKey(value: string): value is PlanKey {
@@ -1250,6 +1269,7 @@ async function setHostingUIRunning(running: boolean, port?: number) {
 	if (running) {
 		serverLogsPanel.style.display = "block";
 		logsOutput.textContent = await window.ollama.getServerLogs();
+		await refreshVerifyTokenUsage();
 	} else {
 		serverLogsPanel.style.display = "none";
 	}
@@ -1264,6 +1284,85 @@ function setServerLogUIRunning(running: boolean, port?: number) {
 	}
 }
 
+function toFiniteRatio(used: number, limit: number | null): number {
+	if (limit == null || limit <= 0) return 0;
+	return Math.max(0, Math.min(1, used / limit));
+}
+
+function renderVerifyTokenUsage(usage: AuthVerifyTokenUsageInfo): void {
+	if (
+		!tokenVerifyUsageValueEl ||
+		!tokenVerifyUsageFillEl ||
+		!tokenVerifyUsageMetaEl
+	) {
+		return;
+	}
+
+	const limit =
+		typeof usage.usage.limit === "number" ? usage.usage.limit : 100;
+	const used = Math.max(0, Number(usage.usage.used) || 0);
+	const remaining =
+		typeof usage.usage.remaining === "number"
+			? Math.max(0, usage.usage.remaining)
+			: Math.max(0, limit - used);
+	const ratio = toFiniteRatio(used, limit);
+
+	tokenVerifyUsageValueEl.textContent = `${remaining} left today`;
+	tokenVerifyUsageMetaEl.textContent = usage.error
+		? `Usage check problem: ${usage.error}`
+		: `${used} / ${limit} used today${usage.generatedAt ? ` • updated ${new Date(usage.generatedAt).toLocaleTimeString()}` : ""}`;
+
+	tokenVerifyUsageFillEl.classList.remove("is-warning", "is-danger");
+	tokenVerifyUsageFillEl.style.width = `${Math.round(ratio * 100)}%`;
+	if (ratio >= 1) {
+		tokenVerifyUsageFillEl.classList.add("is-danger");
+	} else if (ratio >= 0.75) {
+		tokenVerifyUsageFillEl.classList.add("is-warning");
+	}
+
+	if (tokenVerifyUsageNoticeEl) {
+		tokenVerifyUsageNoticeEl.textContent =
+			usage.notice ||
+			"Need more usage? Contact us at inferenceportai@gmail.com.";
+	}
+}
+
+async function refreshVerifyTokenUsage(): Promise<void> {
+	if (
+		!tokenVerifyUsageValueEl ||
+		!tokenVerifyUsageFillEl ||
+		!tokenVerifyUsageMetaEl
+	) {
+		return;
+	}
+
+	tokenVerifyUsageValueEl.textContent = "Loading...";
+	tokenVerifyUsageMetaEl.textContent = "Checking remaining usage...";
+	tokenVerifyUsageFillEl.classList.remove("is-warning", "is-danger");
+	tokenVerifyUsageFillEl.style.width = "0%";
+
+	try {
+		const usage = await window.auth.getVerifyTokenUsage();
+		renderVerifyTokenUsage(usage);
+	} catch (error) {
+		renderVerifyTokenUsage({
+			planKey: "free",
+			planName: "Free Tier",
+			featureName: "Token Verification Requests",
+			usage: {
+				limit: 100,
+				used: 0,
+				remaining: 100,
+				window: "",
+				period: "daily",
+			},
+			generatedAt: null,
+			error: error instanceof Error ? error.message : String(error),
+			notice: "Need more usage? Contact us at inferenceportai@gmail.com.",
+		});
+	}
+}
+
 logsRefreshBtn?.addEventListener("click", async () => {
 	if (!logsOutput) return;
 	logsOutput.textContent = "Loading...";
@@ -1271,6 +1370,7 @@ logsRefreshBtn?.addEventListener("click", async () => {
 		const data = await window.ollama.getServerLogs();
 		logsOutput.textContent = data || "";
 		logsOutput.scrollTop = logsOutput.scrollHeight;
+		await refreshVerifyTokenUsage();
 	} catch (e: any) {
 		logsOutput.textContent = `Error: ${e?.message || e}`;
 	}
@@ -1329,6 +1429,7 @@ async function isLocalProxyRunning(
 				const data = await window.ollama.getServerLogs();
 				if (logsOutput) logsOutput.textContent = data || "";
 			} catch {}
+			await refreshVerifyTokenUsage();
 		}
 	} catch (e) {}
 })();

--- a/src/public/settings.html
+++ b/src/public/settings.html
@@ -186,6 +186,22 @@
 						<div id="server-logs-panel" class="server-logs-panel">
 							<label>Server Logs &nbsp;&nbsp;&nbsp; <a id="logs-refresh" href="javascript:void(0)">Refresh</a></label>
 							<pre id="logs-output"></pre>
+							<div id="token-verify-usage-panel" class="token-verify-usage-panel" aria-live="polite">
+								<div class="token-verify-usage-head">
+									<div>
+										<p class="token-verify-usage-kicker">Daily hosting usage</p>
+										<p class="token-verify-usage-title">Token Verification Requests</p>
+									</div>
+									<span id="token-verify-usage-value" class="token-verify-usage-value">Loading...</span>
+								</div>
+								<div class="token-verify-usage-meter">
+									<div id="token-verify-usage-fill" class="token-verify-usage-fill"></div>
+								</div>
+								<p id="token-verify-usage-meta" class="token-verify-usage-meta">Checking remaining usage...</p>
+								<p id="token-verify-usage-notice" class="token-verify-usage-notice">
+									Need more usage? Contact us at inferenceportai@gmail.com.
+								</p>
+							</div>
 						</div>
 						</div>
 						<div class="tab-pane" id="tools">

--- a/src/public/styles/pages/settings.css
+++ b/src/public/styles/pages/settings.css
@@ -495,6 +495,87 @@ Copyright 2025 Rihaan Meher
   word-break: break-word;
 }
 
+.token-verify-usage-panel {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-light) 86%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-dark) 14%, transparent);
+  display: grid;
+  gap: 8px;
+}
+
+.token-verify-usage-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.token-verify-usage-kicker {
+  margin: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.74;
+}
+
+.token-verify-usage-title {
+  margin: 2px 0 0;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.token-verify-usage-value {
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.token-verify-usage-meter {
+  width: 100%;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-dark) 10%, transparent);
+  overflow: hidden;
+}
+
+.token-verify-usage-fill {
+  width: 0%;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--blue) 80%, #2eaf62 20%),
+    color-mix(in srgb, #2eaf62 85%, #ffd84d 15%)
+  );
+  transition: width 240ms ease;
+}
+
+.token-verify-usage-fill.is-warning {
+  background: linear-gradient(90deg, #f0a738, #f6d14f);
+}
+
+.token-verify-usage-fill.is-danger {
+  background: linear-gradient(90deg, #db5d5d, #f28d8d);
+}
+
+.token-verify-usage-meta,
+.token-verify-usage-notice {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.token-verify-usage-meta {
+  opacity: 0.82;
+}
+
+.token-verify-usage-notice {
+  opacity: 0.72;
+}
+
 .settings-footer {
   margin: 18px 4px 0;
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary by Sourcery

Add UI and backend support to display and enforce daily token verification usage limits for hosting and proxy traffic.

New Features:
- Show a token verification daily usage bar in the settings server logs panel, including remaining quota, detailed metadata, and notices.
- Expose a new auth API to fetch per-plan token verification usage from the subscription service and surface it to the renderer.

Enhancements:
- Update proxy token verification to be promise-based, include bearer auth where available, and propagate limit/usage information back to clients on 429 responses.
- Adjust encrypted proxy capability negotiation to be per-client and bearer-aware, clarifying logging and behavior when encrypted transport is not granted.
- Refine lightning API key revocation modal typing and error handling for more robust UI feedback.