### PR TITLE
Relax chat color-tag rules and clarify LaTeX usage

### DIFF
--- a/src/node-apis/chatStream.ts
+++ b/src/node-apis/chatStream.ts
@@ -646,7 +646,7 @@ const systemPrompt =
   "(Always open with ```svg, then a newline, then the SVG XML, then a newline, then closing triple backticks.) " +
 
   "Never use single backslashes. Don't be overly technical unless the user asks. You may use emojis where appropriate. " +
-  "CRITICAL RULE Never use square brackets or parenthesis () spanning multiple lines within latex eg. \\[...\\]. RESPONSE must be USING ONLY $ AND $$ FOR LATEX " +
+  "CRITICAL RULE Never use square brackets or parenthesis \\(\\) spanning multiple lines within latex eg. \\[...\\]. RESPONSE must be USING ONLY $ AND $$ FOR LATEX " +
   "REMINDER: Color every response with <span data-color=\\\"{COLOR NAME}\\\"> tags. Never return plain text UNLESS THE USER ASKS TO NOT USE COLOR. " +
   "And use markdown for everything other than coloring your text. Use tables, lists, and other markdown elements.";
 

--- a/src/node-apis/chatStream.ts
+++ b/src/node-apis/chatStream.ts
@@ -618,8 +618,7 @@ async function runDirectAudioToolCall(
 
 const systemPrompt =
   "CRITICAL RULE: Every response MUST use HTML <span data-color=\\\"{COLOR NAME}\\\"> tags to color main points and headings UNLESS THE USER ASKS FOR NO COLOR" +
-  "COLORS MUST HAVE MEANING AND CONSISTENCY ACROSS THE ENTIRE CONVERSATION IF USED. " +
-  "You may ONLY use the following semantic color names: " +
+  "COLORS MUST HAVE MEANING AND CONSISTENCY ACROSS THE ENTIRE CONVERSATION IF USED. " +  "You may ONLY use the following semantic color names: " +
   "green, pink, blue, red, orange, yellow, purple, teal, gold, coral. " +
   "Never output text formatted with explicit black or white colors — no exceptions. " +
   "Use a variety of colors throughout every response to distinguish headings, sections, and key terms UNLESS THE USER ASKS NO COLOR. " +

--- a/src/node-apis/chatStream.ts
+++ b/src/node-apis/chatStream.ts
@@ -617,12 +617,12 @@ async function runDirectAudioToolCall(
 
 
 const systemPrompt =
-  "CRITICAL RULE: Every response MUST use HTML <span data-color=\\\"{COLOR NAME}\\\"> tags to color main points and headings. " +
-  "COLORS MUST HAVE MEANING AND CONSISTENCY ACROSS THE ENTIRE CONVERSATION. " +
+  "CRITICAL RULE: Every response MUST use HTML <span data-color=\\\"{COLOR NAME}\\\"> tags to color main points and headings UNLESS THE USER ASKS FOR NO COLOR" +
+  "COLORS MUST HAVE MEANING AND CONSISTENCY ACROSS THE ENTIRE CONVERSATION IF USED. " +
   "You may ONLY use the following semantic color names: " +
   "green, pink, blue, red, orange, yellow, purple, teal, gold, coral. " +
   "Never output text formatted with explicit black or white colors — no exceptions. " +
-  "Use a variety of colors throughout every response to distinguish headings, sections, and key terms. " +
+  "Use a variety of colors throughout every response to distinguish headings, sections, and key terms UNLESS THE USER ASKS NO COLOR. " +
   "Color should guide the reader and reinforce meaning. " +
   "Keep code blocks plain, but color headings and important points in surrounding text. " +
   "Ensure sufficient contrast for readability, but NO DARK OR EXTRA‑BRIGHT COLORS. " +
@@ -647,8 +647,8 @@ const systemPrompt =
   "(Always open with ```svg, then a newline, then the SVG XML, then a newline, then closing triple backticks.) " +
 
   "Never use single backslashes. Don't be overly technical unless the user asks. You may use emojis where appropriate. " +
-
-  "REMINDER: Color every response with <span data-color=\\\"{COLOR NAME}\\\"> tags. Never return plain text. " +
+  "CRITICAL RULE Never use square brackets or parenthesis () spanning multiple lines within latex eg. \\[...\\]. RESPONSE must be USING ONLY $ AND $$ FOR LATEX " +
+  "REMINDER: Color every response with <span data-color=\\\"{COLOR NAME}\\\"> tags. Never return plain text UNLESS THE USER ASKS TO NOT USE COLOR. " +
   "And use markdown for everything other than coloring your text. Use tables, lists, and other markdown elements.";
 
 

--- a/src/public/scripts/renderer/snip-chat.ts
+++ b/src/public/scripts/renderer/snip-chat.ts
@@ -18,7 +18,7 @@ const secureRandomHex = Array.from(window.crypto.getRandomValues(new Uint8Array(
 	.join("");
 const sessionId = `snip-${Date.now()}-${secureRandomHex}`;
 const DEFAULT_PROMPT =
-	"Analyze the image, extract any text, and determine whether the user expects a description, an answer, or a solution. If the image contains a question or problem, solve it. If it contains objects or scenes, describe only what is visually evident. Do not infer identity, emotions, or private details.";
+	"Analyze the image, extract any text, and determine whether the user expects a description, an answer, or a solution. If the image contains a question or problem, solve it. If it contains objects or scenes, describe only what is visually evident. Do not infer identity, emotions, or private details. Do not use data-color tags.";
 const MODEL = "lightning";
 const CLIENT_URL = "lightning";
 


### PR DESCRIPTION
## Summary by Sourcery

Relax color-tagging requirements in the chat system prompt and update snip-chat’s default prompt to avoid using color tags.

Enhancements:
- Allow responses to omit color tags when the user explicitly requests no color while keeping semantic color guidance when used.
- Clarify LaTeX formatting rules in the system prompt to require only $ and $$ delimiters and avoid multi-line bracket/parenthesis forms.
- Update snip-chat’s default image analysis prompt to explicitly forbid using data-color tags in its responses.