### PR TITLE
[INTERNAL] Tighten IPC WebSocket bridge typings and declare ws deps

### DIFF
--- a/src/node-apis/helper/ipcBridge.ts
+++ b/src/node-apis/helper/ipcBridge.ts
@@ -13,6 +13,7 @@ import { WebSocketServer, type WebSocket } from "ws";
 import fs from "fs";
 import path from "path";
 import { sanitizeForLog } from "./server.js";
+import type { IncomingMessage } from "http";
 
 type InvokeHandler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
 type OnHandler = (event: IpcMainEvent, ...args: unknown[]) => unknown;
@@ -123,7 +124,7 @@ function loadOrCreateWsAuthToken(): string {
 
 			return existing || generated;
 		}
-	} catch (err) {
+	} catch (err: unknown) {
 		console.warn(
 			sanitizeForLog("Unable to load websocket auth token from userData"),
 			err,
@@ -423,7 +424,7 @@ export function broadcastIpcEvent(channel: string, ...args: unknown[]): void {
 	for (const win of BrowserWindow.getAllWindows()) {
 		try {
 			win.webContents.send(channel, ...args);
-		} catch (err) {
+		} catch (err: unknown) {
 			console.warn(
 				"Failed to broadcast IPC event",
 				sanitizeForLog(channel),
@@ -493,7 +494,7 @@ export function initIpcWebSocketBridge(options: IpcBridgeOptions = {}): void {
 		perMessageDeflate: false,
 	});
 
-	wsServer.on("connection", (ws, req) => {
+	wsServer.on("connection", (ws: WebSocket, req: IncomingMessage) => {
 		const originHeader =
 			typeof req.headers.origin === "string"
 				? normalizeOrigin(req.headers.origin.trim().toLowerCase())
@@ -649,7 +650,7 @@ export function initIpcWebSocketBridge(options: IpcBridgeOptions = {}): void {
 						ok: true,
 						value: encodeValue(value),
 					});
-				} catch (err) {
+				} catch (err: unknown) {
 					sendWs(ws, {
 						type: "result",
 						id: message.id,
@@ -662,7 +663,7 @@ export function initIpcWebSocketBridge(options: IpcBridgeOptions = {}): void {
 
 			if (message.type === "send") {
 				if (!message.id) {
-					void dispatchSend(message, ws).catch((err) => {
+					void dispatchSend(message, ws).catch((err: unknown) => {
 						console.warn(
 							sanitizeForLog(
 								`IPC send dispatch failed for '${message.channel}'`,
@@ -681,7 +682,7 @@ export function initIpcWebSocketBridge(options: IpcBridgeOptions = {}): void {
 						ok: true,
 						value: encodeValue(value),
 					});
-				} catch (err) {
+				} catch (err: unknown) {
 					sendWs(ws, {
 						type: "result",
 						id: message.id,
@@ -706,7 +707,7 @@ export function initIpcWebSocketBridge(options: IpcBridgeOptions = {}): void {
 		);
 	});
 
-	wsServer.on("error", (err) => {
+	wsServer.on("error", (err: unknown) => {
 		console.error("IPC websocket bridge error", err);
 	});
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -19,7 +19,8 @@
         "markdown-it-table": "^4.1.1",
         "openai": "^6.36.0",
         "sanitize-html": "^2.17.4",
-        "systeminformation": "^5.31.6"
+        "systeminformation": "^5.31.6",
+        "ws": "^8.20.1"
       },
       "devDependencies": {
         "@types/dompurify": "^3.2.0",
@@ -28,6 +29,7 @@
         "@types/node": "^25.7.0",
         "@types/sanitize-html": "^2.16.1",
         "@types/tar": "^7.0.87",
+        "@types/ws": "^8.18.1",
         "@typescript/native-preview": "^7.0.0-dev.20260511.1",
         "electron": "^42.1.0",
         "electron-builder": "^26.8.1",
@@ -5555,9 +5557,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/src/package.json
+++ b/src/package.json
@@ -29,7 +29,8 @@
     "markdown-it-table": "^4.1.1",
     "openai": "^6.36.0",
     "sanitize-html": "^2.17.4",
-    "systeminformation": "^5.31.6"
+    "systeminformation": "^5.31.6",
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "@types/dompurify": "^3.2.0",
@@ -38,6 +39,7 @@
     "@types/node": "^25.7.0",
     "@types/sanitize-html": "^2.16.1",
     "@types/tar": "^7.0.87",
+    "@types/ws": "^8.18.1",
     "@typescript/native-preview": "^7.0.0-dev.20260511.1",
     "electron": "^42.1.0",
     "electron-builder": "^26.8.1",


### PR DESCRIPTION
## Summary by Sourcery

Tighten TypeScript typings around the IPC WebSocket bridge and add explicit WebSocket dependencies.

Enhancements:
- Annotate IPC WebSocket bridge error handlers and async callbacks with explicit unknown error types for safer error handling.
- Type the WebSocket server connection callback parameters with concrete WebSocket and HTTP IncomingMessage types.

Build:
- Declare ws and its TypeScript type definitions as explicit runtime and development dependencies in src/package.json.