### PR TITLE
Potential fix for code scanning alert no. 9024: Log injection

### DIFF
--- a/src/public/scripts/helper/ipcTransportFallback.ts
+++ b/src/public/scripts/helper/ipcTransportFallback.ts
@@ -224,10 +224,15 @@ class WsIpcClient {
 		this.pending.clear();
 	}
 
-	private onServerMessage(raw: unknown): void {
-		const rawLog = String(raw)
+	private sanitizeForLog(value: unknown, maxLen: number): string {
+		return String(value)
+			.replace(/[\r\n\u2028\u2029]/g, " ")
 			.replace(/[\x00-\x1F\x7F]/g, " ")
-			.slice(0, 500);
+			.slice(0, maxLen);
+	}
+
+	private onServerMessage(raw: unknown): void {
+		const rawLog = this.sanitizeForLog(raw, 500);
 		console.log("Received IPC message", rawLog);
 		if (typeof raw !== "string") return;
 
@@ -285,9 +290,7 @@ class WsIpcClient {
 				try {
 					handler(...args);
 				} catch (err) {
-					const channelLog = String(message.channel)
-						.replace(/[\x00-\x1F\x7F]/g, " ")
-						.slice(0, 200);
+					const channelLog = this.sanitizeForLog(message.channel, 200);
 					console.warn(
 						"IPC event listener failed for",
 						channelLog,


### PR DESCRIPTION
Potential fix for [https://github.com/sharktide/inferenceport-ai/security/code-scanning/9024](https://github.com/sharktide/inferenceport-ai/security/code-scanning/9024)

General fix approach: ensure any user-controlled/untrusted data is sanitized specifically for log safety before passing it to `console.*`. For plain-text logs, strip line breaks and non-printable control characters, and optionally cap length.

Best single fix here (without changing behavior): add a dedicated helper method in `ipcTransportFallback.ts` (for example `sanitizeForLog`) that:
- converts input to string,
- replaces `\r`, `\n`, `\u2028`, `\u2029` with spaces,
- removes remaining control characters,
- truncates to existing limits.

Then use this helper for both `rawLog` and `channelLog` so sanitization is consistent and explicit.  
Changes are limited to `src/public/scripts/helper/ipcTransportFallback.ts` in:
- `onServerMessage` (lines around 227–231),
- event-listener error logging block (lines around 288–293),
- plus insertion of the new private helper method in the same class (near these methods).

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Improve logging safety by sanitizing untrusted IPC message data before it is written to logs.

Bug Fixes:
- Prevent potential log injection by sanitizing untrusted IPC message and channel values before logging.

Enhancements:
- Introduce a reusable log-sanitization helper to consistently clean and truncate IPC-related log messages.