### PR TITLE
Potential fix for code scanning alert no. 9023: Log injection

### DIFF
--- a/src/public/scripts/helper/ipcTransportFallback.ts
+++ b/src/public/scripts/helper/ipcTransportFallback.ts
@@ -226,7 +226,7 @@ class WsIpcClient {
 
 	private onServerMessage(raw: unknown): void {
 		const rawType = typeof raw;
-		const rawSize = rawType === "string" ? raw.length : null;
+		const rawSize = typeof raw === "string" ? raw.length : null;
 		console.log("Received IPC message", { type: rawType, size: rawSize });
 		if (typeof raw !== "string") return;
 

--- a/src/public/scripts/helper/ipcTransportFallback.ts
+++ b/src/public/scripts/helper/ipcTransportFallback.ts
@@ -225,10 +225,9 @@ class WsIpcClient {
 	}
 
 	private onServerMessage(raw: unknown): void {
-		const rawLog = String(raw)
-			.replace(/[\x00-\x1F\x7F]/g, " ")
-			.slice(0, 500);
-		console.log("Received IPC message", rawLog);
+		const rawType = typeof raw;
+		const rawSize = rawType === "string" ? raw.length : null;
+		console.log("Received IPC message", { type: rawType, size: rawSize });
 		if (typeof raw !== "string") return;
 
 		void this.handleIncomingMessage(raw);


### PR DESCRIPTION
Potential fix for [https://github.com/sharktide/inferenceport-ai/security/code-scanning/9023](https://github.com/sharktide/inferenceport-ai/security/code-scanning/9023)

General fix: do not log raw user-controlled message content. Instead, log only safe metadata (such as type and size), or fully sanitize and encode content for the target log format.

Best fix here (without changing functionality): in `onServerMessage`, replace logging of `rawLog` with a metadata-only message derived from type/length. This preserves observability (“message received”) while removing tainted payload content from logs.  
Edit only `src/public/scripts/helper/ipcTransportFallback.ts`, specifically the `onServerMessage` method around lines 227–232:
- Remove `rawLog` construction.
- Compute `rawType` and `rawSize` safely.
- Log `Received IPC message` with `{ type, size }`.

No new imports, dependencies, or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent potential log injection by avoiding logging raw IPC message content and instead logging only its type and size.