### PR TITLE
[debug] Fix build workflow fatal errors on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,20 +197,32 @@ jobs:
         working-directory: src
         shell: bash
         run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            EXE="vendor/electron-ollama/ollama.exe"
-          else
-            EXE="vendor/electron-ollama/ollama"
-          fi
+          case "$RUNNER_OS" in
+            "Windows")
+              EXE="vendor/electron-ollama/ollama.exe"
+              ;;
+            "macOS")
+              EXE="vendor/electron-ollama/ollama"
+              ;;
+            "Linux")
+              EXE="vendor/electron-ollama/bin/ollama"
+              ;;
+            *)
+              echo "❌ Unsupported OS: $RUNNER_OS"
+              exit 1
+              ;;
+          esac
+
           if [ ! -f "$EXE" ]; then
             echo "❌ Bundle failed: $EXE not found"
             echo "── vendor tree ──"
             find vendor/electron-ollama -maxdepth 4 | sort || true
             exit 1
           fi
+
           echo "✅ Ollama bundled: $EXE ($(du -sh "$EXE" | cut -f1))"
 
-      # ── Electron-builder ──────────────────────────────────────────────────
+
       - name: Build Electron app
         working-directory: src
         run: npx electron-builder --config build.config.js --publish never

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,102 +45,175 @@ jobs:
             artifact: Electron-win64-build
             path: src/dist/*
             accel: cpu
+            rust_target: x86_64-pc-windows-msvc
 
           - os: windows-11-arm
             name: Windows ARM64
             artifact: Electron-win-arm64-build
             path: src/dist/*
             accel: cpu
+            rust_target: aarch64-pc-windows-msvc
 
           - os: macos-latest
             name: macOS ARM64
             artifact: Electron-mac-arm64-build
             path: src/dist/*.*
             accel: cpu
+            rust_target: aarch64-apple-darwin
 
           - os: macos-15-intel
             name: macOS x86_64
             artifact: Electron-mac-x64-build
             path: src/dist/*.*
             accel: cpu
+            rust_target: x86_64-apple-darwin
 
           - os: ubuntu-latest
             name: Linux x86_64
             artifact: Electron-linux-x64-build
             path: src/dist/*.*
             accel: cpu
+            rust_target: x86_64-unknown-linux-gnu
 
           - os: ubuntu-24.04-arm
             name: Linux ARM64
             artifact: Electron-linux-arm64-build
             path: src/dist/*.*
             accel: cpu
+            rust_target: aarch64-unknown-linux-gnu
 
           - os: windows-latest
             name: Windows CUDA
             artifact: Electron-win64-cuda
             path: src/dist/*.*
             accel: cuda
+            rust_target: x86_64-pc-windows-msvc
 
           - os: ubuntu-latest
             name: Linux CUDA x86_64
             artifact: Electron-linux-cuda
             path: src/dist/*.*
             accel: cuda
+            rust_target: x86_64-unknown-linux-gnu
 
           - os: ubuntu-24.04-arm
             name: Linux ARM CUDA
             artifact: Electron-linux-arm-cuda
             path: src/dist/*.*
             accel: cuda
+            rust_target: aarch64-unknown-linux-gnu
 
           - os: windows-latest
             name: Windows ROCm
             artifact: Electron-win64-rocm
             path: src/dist/*.*
             accel: rocm
+            rust_target: x86_64-pc-windows-msvc
 
           - os: ubuntu-latest
             name: Linux ROCm
             artifact: Electron-linux-rocm
             path: src/dist/*.*
             accel: rocm
+            rust_target: x86_64-unknown-linux-gnu
 
           - os: ubuntu-24.04-arm
             name: JetPack 5
             artifact: Electron-jetpack5
             path: src/dist/*.*
             accel: jetpack5
+            rust_target: aarch64-unknown-linux-gnu
 
           - os: ubuntu-24.04-arm
             name: JetPack 6
             artifact: Electron-jetpack6
             path: src/dist/*.*
             accel: jetpack6
+            rust_target: aarch64-unknown-linux-gnu
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine accelerator
-        shell: bash
-        env:
-          DISPATCH_ACCEL: ${{ github.event.inputs.accelerator }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
+      # ── Windows: long-path support + disable Defender real-time scanning ──
+      - name: Windows – enable long paths
+        if: runner.os == 'Windows'
+        shell: powershell
         run: |
-          echo "ACCELERATOR=${{ matrix.accel }}" >> $GITHUB_ENV
-          echo "OLLAMA_ACCELERATION=${{ matrix.accel }}" >> $GITHUB_ENV
+          git config --global core.longpaths true
+          Set-ItemProperty `
+            -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' `
+            -Name LongPathsEnabled -Value 1
 
+      - name: Windows – disable Defender real-time monitoring
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
+      # ── Rust (required for napi:build) ────────────────────────────────────
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/lib
+
+      # ── Node ──────────────────────────────────────────────────────────────
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: npm
+          cache-dependency-path: src/package-lock.json
+
+      - name: Set accelerator env
+        shell: bash
+        run: |
+          echo "ACCELERATOR=${{ matrix.accel }}" >> $GITHUB_ENV
+          echo "OLLAMA_ACCELERATION=${{ matrix.accel }}" >> $GITHUB_ENV
 
       - name: Install deps
         working-directory: src
         run: npm ci
 
-      - name: Build Electron
+      # ── Build native addon ────────────────────────────────────────────────
+      - name: Build native addon (napi)
         working-directory: src
-        run: npm run build
+        run: npx napi build --release --manifest-path lib/Cargo.toml --output-dir lib/out
+
+      # ── Compile TypeScript ────────────────────────────────────────────────
+      - name: Compile TypeScript
+        working-directory: src
+        run: npx tsgo
+
+      # ── Bundle Ollama (split out so failures are visible) ─────────────────
+      - name: Bundle Ollama
+        working-directory: src
+        shell: bash
+        run: node scripts/bundle-ollama.js
+
+      - name: Verify Ollama bundle
+        working-directory: src
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            EXE="vendor/electron-ollama/ollama.exe"
+          else
+            EXE="vendor/electron-ollama/ollama"
+          fi
+          if [ ! -f "$EXE" ]; then
+            echo "❌ Bundle failed: $EXE not found"
+            echo "── vendor tree ──"
+            find vendor/electron-ollama -maxdepth 4 | sort || true
+            exit 1
+          fi
+          echo "✅ Ollama bundled: $EXE ($(du -sh "$EXE" | cut -f1))"
+
+      # ── Electron-builder ──────────────────────────────────────────────────
+      - name: Build Electron app
+        working-directory: src
+        run: npx electron-builder --config build.config.js --publish never
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/win_debug.yml
+++ b/.github/workflows/win_debug.yml
@@ -1,0 +1,47 @@
+name: Windows Debug Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Debug build
+        run: |
+          cd src
+
+          Write-Host "=== Node Version ==="
+          node --version
+
+          Write-Host "=== NPM Version ==="
+          npm --version
+
+          Write-Host "=== Running npm ci ==="
+          npm ci
+
+          Write-Host "=== Running prepack ==="
+          npm run prepack
+
+          Write-Host "=== Vendor Directory Tree ==="
+          if (Test-Path vendor) {
+            tree vendor /F
+          } else {
+            Write-Host "vendor directory not found"
+          }
+
+          Write-Host "=== Running build ==="
+          npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -855,6 +855,10 @@ dist\win-unpacked\resources\app\public\scripts\staticload\theme.d.ts
 dist\win-unpacked\resources\app\public\scripts\staticload\theme.d.ts.map
 dist\win-unpacked\resources\app\public\scripts\staticload\theme.js
 dist\win-unpacked\resources\app\public\scripts\staticload\theme.js.map
+dist\win-unpacked\resources\lib\index.d.d.ts
+dist\win-unpacked\resources\lib\index.d.d.ts.map
+dist\win-unpacked\resources\lib\index.d.js
+dist\win-unpacked\resources\lib\index.d.js.map
 dlldata.c
 docs/build/
 ecf/

--- a/src/lib/Cargo.lock
+++ b/src/lib/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "ipai_native_addons"
-version = "0.1.0"
+version = "2.12.0"
 dependencies = [
  "ammonia",
  "html-escape",


### PR DESCRIPTION
## Summary by Sourcery

Update the build workflow to reliably build and package the Electron app with native Rust-based addons across all platforms, with improved Windows compatibility and clearer build steps.

Build:
- Add explicit Rust targets per matrix entry and set up a Rust toolchain and cache for the napi-based native addon build.
- Enhance the GitHub Actions workflow with Windows long-path support, Defender disabling, and split build steps for native addon, TypeScript compile, Ollama bundling, and Electron packaging via electron-builder.
- Enable Node.js dependency caching in CI using npm cache and the src/package-lock.json dependency path.