### PR TITLE
Potential fix for code scanning alert no. 9024: Log injection

### DIFF
--- a/src/public/scripts/helper/ipcTransportFallback.ts
+++ b/src/public/scripts/helper/ipcTransportFallback.ts
@@ -285,9 +285,9 @@ class WsIpcClient {
 					handler(...args);
 				} catch (err) {
 					const channelLog = String(message.channel)
-						.replace(/[\r\n\u2028\u2029\u0085]|[\x00-\x1F\x7F]/g, " ")
-						.trim()
-						.slice(0, 200);
+						.slice(0, 200)
+						.replace(/[\x00-\x1F\x7F\u2028\u2029\u0085]/g, " ")
+						.trim();
 					console.warn(
 						"IPC event listener failed for",
 						channelLog,

--- a/src/public/scripts/helper/ipcTransportFallback.ts
+++ b/src/public/scripts/helper/ipcTransportFallback.ts
@@ -285,7 +285,8 @@ class WsIpcClient {
 					handler(...args);
 				} catch (err) {
 					const channelLog = String(message.channel)
-						.replace(/[\x00-\x1F\x7F]/g, " ")
+						.replace(/[\r\n\u2028\u2029\u0085]|[\x00-\x1F\x7F]/g, " ")
+						.trim()
 						.slice(0, 200);
 					console.warn(
 						"IPC event listener failed for",


### PR DESCRIPTION
Potential fix for [https://github.com/sharktide/inferenceport-ai/security/code-scanning/9024](https://github.com/sharktide/inferenceport-ai/security/code-scanning/9024)

Best fix: sanitize `message.channel` with a stricter log-safe normalization that removes **all** line-break-like characters and control characters before logging, then truncate. Keep behavior the same otherwise.

In `src/public/scripts/helper/ipcTransportFallback.ts`, inside the `catch (err)` block in `handleIncomingMessage`, replace the current `channelLog` construction (lines 287–289 area) with one that:
- coerces to string,
- replaces CR/LF and Unicode separators (`\u2028`, `\u2029`, `\u0085`) plus ASCII controls with spaces,
- trims and truncates to current max length.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent potential log injection by stripping line-break and control characters from IPC channel names before logging and trimming the result.