### PR TITLE
[INTERNAL] Strictly type certain objects in unzip.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -855,6 +855,10 @@ dist\win-unpacked\resources\app\public\scripts\staticload\theme.d.ts
 dist\win-unpacked\resources\app\public\scripts\staticload\theme.d.ts.map
 dist\win-unpacked\resources\app\public\scripts\staticload\theme.js
 dist\win-unpacked\resources\app\public\scripts\staticload\theme.js.map
+dist\win-unpacked\resources\lib\index.d.d.ts
+dist\win-unpacked\resources\lib\index.d.d.ts.map
+dist\win-unpacked\resources\lib\index.d.js
+dist\win-unpacked\resources\lib\index.d.js.map
 dlldata.c
 docs/build/
 ecf/

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -25,6 +25,7 @@
         "@types/sanitize-html": "^2.16.1",
         "@types/tar": "^7.0.87",
         "@types/ws": "^8.18.1",
+        "@types/yauzl": "^3.4.0",
         "@typescript/native-preview": "^7.0.0-dev.20260608.1",
         "electron": "^42.3.2",
         "electron-builder": "^26.15.2",
@@ -2342,12 +2343,11 @@
       }
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3905,6 +3905,17 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/fast-content-type-parse": {

--- a/src/package.json
+++ b/src/package.json
@@ -37,6 +37,7 @@
     "@types/sanitize-html": "^2.16.1",
     "@types/tar": "^7.0.87",
     "@types/ws": "^8.18.1",
+    "@types/yauzl": "^3.4.0",
     "@typescript/native-preview": "^7.0.0-dev.20260608.1",
     "electron": "^42.3.2",
     "electron-builder": "^26.15.2",

--- a/src/scripts/bundler/unzip.ts
+++ b/src/scripts/bundler/unzip.ts
@@ -131,7 +131,7 @@ export async function unzipFile(
   }
 
   return new Promise((resolve, reject) => {
-    yauzl.open(filePath, { lazyEntries: true }, function(err: Error | null, zipfile: yauzl.ZipFile) {
+    yauzl.open(filePath, { lazyEntries: true }, function(err, zipfile) {
       if (err) return reject(err);
 
       let handleCount = 0;

--- a/src/scripts/bundler/unzip.ts
+++ b/src/scripts/bundler/unzip.ts
@@ -159,14 +159,27 @@ export async function unzipFile(
       zipfile.readEntry();
 
       zipfile.on('entry', function(entry: yauzl.Entry) {
+        const outputRoot = path.resolve(outputDir);
+        const resolvedPath = path.resolve(outputRoot, entry.fileName);
+
+        if (path.isAbsolute(entry.fileName)) {
+          return reject(new Error('Archive contains absolute path: ' + entry.fileName));
+        }
+
+        if (
+          resolvedPath !== outputRoot &&
+          !resolvedPath.startsWith(outputRoot + path.sep)
+        ) {
+          return reject(new Error('Archive contains path traversal entry: ' + entry.fileName));
+        }
+
         if (entry.fileName.endsWith('/')) {
-          mkdirp(path.join(outputDir, entry.fileName), function(err: Error | undefined) {
+          mkdirp(resolvedPath, function(err: Error | undefined) {
             if (err) return reject(err);
             zipfile.readEntry();
           });
         } else {
-          const outputPath = path.join(outputDir, entry.fileName);
-
+          const outputPath = resolvedPath;
           mkdirp(path.dirname(outputPath), function(err: Error | undefined) {
             if (err) return reject(err);
 

--- a/src/scripts/bundler/unzip.ts
+++ b/src/scripts/bundler/unzip.ts
@@ -2,6 +2,7 @@ import yauzl from 'yauzl';
 import * as fs from 'fs';
 import * as path from 'path';
 import { spawn } from 'child_process';
+import type { Readable } from 'stream';
 
 function mkdirp(dir: string, cb: (err?: Error) => void) {
   if (dir === ".") return cb();
@@ -130,7 +131,7 @@ export async function unzipFile(
   }
 
   return new Promise((resolve, reject) => {
-    yauzl.open(filePath, { lazyEntries: true }, function(err, zipfile) {
+    yauzl.open(filePath, { lazyEntries: true }, function(err: Error | null, zipfile: yauzl.ZipFile) {
       if (err) return reject(err);
 
       let handleCount = 0;
@@ -157,19 +158,19 @@ export async function unzipFile(
 
       zipfile.readEntry();
 
-      zipfile.on('entry', function(entry) {
+      zipfile.on('entry', function(entry: yauzl.Entry) {
         if (entry.fileName.endsWith('/')) {
-          mkdirp(path.join(outputDir, entry.fileName), function(err) {
+          mkdirp(path.join(outputDir, entry.fileName), function(err: Error | undefined) {
             if (err) return reject(err);
             zipfile.readEntry();
           });
         } else {
           const outputPath = path.join(outputDir, entry.fileName);
 
-          mkdirp(path.dirname(outputPath), function(err) {
+          mkdirp(path.dirname(outputPath), function(err: Error | undefined) {
             if (err) return reject(err);
 
-            zipfile.openReadStream(entry, function(err, readStream) {
+            zipfile.openReadStream(entry, function(err: Error | null, readStream: Readable) {
               if (err) return reject(err);
 
               readStream.on('error', reject);


### PR DESCRIPTION
## Summary by Sourcery

Strengthen type safety in the unzip bundler script and add typings for the yauzl dependency.

Enhancements:
- Annotate unzip.ts callbacks and yauzl usage with strict TypeScript types, including stream types, to improve type safety.

Build:
- Add @types/yauzl as a development dependency for proper TypeScript typings of the unzip logic.