### PR TITLE
[INTERNAL] Re-add yauzl to dev dependencies

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -30,7 +30,8 @@
         "electron": "^42.3.2",
         "electron-builder": "^26.15.2",
         "glob": "^13.0.6",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "yauzl": "^3.4.0"
       }
     },
     "node_modules/@electron/asar": {
@@ -3918,6 +3919,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/extract-zip/node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
@@ -6298,14 +6310,16 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/src/package.json
+++ b/src/package.json
@@ -42,7 +42,8 @@
     "electron": "^42.3.2",
     "electron-builder": "^26.15.2",
     "glob": "^13.0.6",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "yauzl": "^3.4.0"
   },
   "napi": {
     "binaryName": "ipai-native-addons",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update package.json to include yauzl as a dev dependency.